### PR TITLE
Redirect logged-in users from /login to /history

### DIFF
--- a/src/components/landing/pages/login/login.tsx
+++ b/src/components/landing/pages/login/login.tsx
@@ -9,11 +9,14 @@ import {ApplicationState} from "../../../../redux";
 import {ViaOpenId} from "./auth/via-open id";
 import "./login.scss";
 import {ElementSeparator} from "../../../element-separator/element-separator";
+import {Redirect} from "react-router";
+import {LoginStatus} from "../../../../redux/user/types";
 
 const Login: React.FC = () => {
     useTranslation();
     const authProviders = useSelector((state: ApplicationState) => state.backendConfig.authProviders);
     const customAuthNames = useSelector((state: ApplicationState) => state.backendConfig.customAuthNames);
+    const userLoginState = useSelector((state: ApplicationState) => state.user.status);
     const emailForm = authProviders.email ? <ViaEMail/> : null
     const ldapForm = authProviders.ldap ? <ViaLdap/> : null
     const openIdForm = authProviders.openid ? <ViaOpenId/> : null
@@ -27,6 +30,13 @@ const Login: React.FC = () => {
             default:
                 return undefined;
         }
+    }
+    
+    if (userLoginState === LoginStatus.ok) {
+        // TODO Redirect to previous page?
+        return (
+            <Redirect to='/history' />
+        )
     }
 
     return (


### PR DESCRIPTION
Logged-in users that access /login should be redirected to the /history page.
In a future PR we maybe want to redirect users to their previuos page.