### PR TITLE
Make application loader only trigger once

### DIFF
--- a/src/components/application-loader/application-loader.tsx
+++ b/src/components/application-loader/application-loader.tsx
@@ -10,6 +10,7 @@ export const ApplicationLoader: React.FC = ({ children }) => {
   const [doneTasks, setDoneTasks] = useState<number>(0)
   const [initTasks, setInitTasks] = useState<InitTask[]>([])
   const { pathname } = useLocation()
+  const [applicationLoading, setApplicationLoading] = useState<boolean>(false)
 
   const runTask = async (task: Promise<void>): Promise<void> => {
     await task
@@ -19,10 +20,14 @@ export const ApplicationLoader: React.FC = ({ children }) => {
   }
 
   useEffect(() => {
+    if (applicationLoading) {
+      return
+    }
+    setApplicationLoading(true)
     const baseUrl:string = window.location.pathname.replace(pathname, '') + '/'
     console.debug('Base URL is', baseUrl)
     setInitTasks(setUp(baseUrl))
-  }, [pathname])
+  }, [applicationLoading, pathname])
 
   useEffect(() => {
     for (const task of initTasks) {

--- a/src/components/application-loader/application-loader.tsx
+++ b/src/components/application-loader/application-loader.tsx
@@ -10,7 +10,7 @@ export const ApplicationLoader: React.FC = ({ children }) => {
   const [doneTasks, setDoneTasks] = useState<number>(0)
   const [initTasks, setInitTasks] = useState<InitTask[]>([])
   const { pathname } = useLocation()
-  const [applicationLoading, setApplicationLoading] = useState<boolean>(false)
+  const [tasksAlreadyTriggered, setTasksAlreadyTriggered] = useState<boolean>(false)
 
   const runTask = async (task: Promise<void>): Promise<void> => {
     await task
@@ -20,14 +20,14 @@ export const ApplicationLoader: React.FC = ({ children }) => {
   }
 
   useEffect(() => {
-    if (applicationLoading) {
+    if (tasksAlreadyTriggered) {
       return
     }
-    setApplicationLoading(true)
+    setTasksAlreadyTriggered(true)
     const baseUrl:string = window.location.pathname.replace(pathname, '') + '/'
     console.debug('Base URL is', baseUrl)
     setInitTasks(setUp(baseUrl))
-  }, [applicationLoading, pathname])
+  }, [tasksAlreadyTriggered, pathname])
 
   useEffect(() => {
     for (const task of initTasks) {


### PR DESCRIPTION
The application loader has a bug, that causes the loader to re-run the init tasks every time the path changes. This PR fixes this.