### PR TITLE
Show login-buttons and boxes only if providers are configured

### DIFF
--- a/src/components/landing/layout/navigation/sign-in-button.tsx
+++ b/src/components/landing/layout/navigation/sign-in-button.tsx
@@ -13,16 +13,16 @@ type SignInButtonProps = {
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()
   const authProviders = useSelector((state: ApplicationState) => state.backendConfig.authProviders)
-return Object.values(authProviders).includes(true)
+  return Object.values(authProviders).includes(true)
     ? (
-    <LinkContainer to="/login" title={t('login.signIn')}>
-      <Button
-        variant={variant || 'success'}
-        {...props}
-      >
-        <Trans i18nKey="login.signIn"/>
-      </Button>
-    </LinkContainer>
+      <LinkContainer to="/login" title={t('login.signIn')}>
+        <Button
+          variant={variant || 'success'}
+          {...props}
+        >
+          <Trans i18nKey="login.signIn"/>
+        </Button>
+      </LinkContainer>
     )
     : null
 }

--- a/src/components/landing/layout/navigation/sign-in-button.tsx
+++ b/src/components/landing/layout/navigation/sign-in-button.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { LinkContainer } from 'react-router-bootstrap'
 import { ApplicationState } from '../../../../redux'
+import { ShowIf } from '../../../common/show-if'
 
 type SignInButtonProps = {
   className?: string
@@ -13,8 +14,8 @@ type SignInButtonProps = {
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()
   const authProviders = useSelector((state: ApplicationState) => state.backendConfig.authProviders)
-  return Object.values(authProviders).includes(true)
-    ? (
+  return (
+    <ShowIf condition={Object.values(authProviders).includes(true)}>
       <LinkContainer to="/login" title={t('login.signIn')}>
         <Button
           variant={variant || 'success'}
@@ -23,6 +24,6 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
           <Trans i18nKey="login.signIn"/>
         </Button>
       </LinkContainer>
-    )
-    : null
+    </ShowIf>
+  )
 }

--- a/src/components/landing/layout/navigation/sign-in-button.tsx
+++ b/src/components/landing/layout/navigation/sign-in-button.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { Button } from 'react-bootstrap'
 import { ButtonProps } from 'react-bootstrap/Button'
 import { Trans, useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { LinkContainer } from 'react-router-bootstrap'
+import { ApplicationState } from '../../../../redux'
 
 type SignInButtonProps = {
   className?: string
@@ -10,8 +12,9 @@ type SignInButtonProps = {
 
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()
-
-  return (
+  const authProviders = useSelector((state: ApplicationState) => state.backendConfig.authProviders)
+return Object.values(authProviders).includes(true)
+    ? (
     <LinkContainer to="/login" title={t('login.signIn')}>
       <Button
         variant={variant || 'success'}
@@ -20,5 +23,6 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
         <Trans i18nKey="login.signIn"/>
       </Button>
     </LinkContainer>
-  )
+    )
+    : null
 }

--- a/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
+++ b/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { Button } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -18,21 +18,20 @@ export const CoverButtons: React.FC = () => {
 
   return (
     <div className="mb-5">
+      <SignInButton
+        className="cover-button"
+        variant="success"
+        size="lg"
+      />
       {
         Object.values(authProviders).includes(true)
-          ? <Fragment>
-            <SignInButton
-               className="cover-button"
-               variant="success"
-              size="lg"
-            />
+          ? (
             <span className="m-2">
               <Trans i18nKey="common.or"/>
             </span>
-          </Fragment>
+          )
           : null
       }
-
       <Link to="/features">
         <Button
           className="cover-button"

--- a/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
+++ b/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { ApplicationState } from '../../../../../redux'
+import { ShowIf } from '../../../../common/show-if'
 import { SignInButton } from '../../../layout/navigation/sign-in-button'
 import './cover-buttons.scss'
 
@@ -23,15 +24,11 @@ export const CoverButtons: React.FC = () => {
         variant="success"
         size="lg"
       />
-      {
-        Object.values(authProviders).includes(true)
-          ? (
-            <span className="m-2">
-              <Trans i18nKey="common.or"/>
-            </span>
-          )
-          : null
-      }
+      <ShowIf condition={Object.values(authProviders).includes(true)}>
+        <span className="m-2">
+          <Trans i18nKey="common.or"/>
+        </span>
+      </ShowIf>
       <Link to="/features">
         <Button
           className="cover-button"

--- a/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
+++ b/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { Button } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -10,6 +10,7 @@ import './cover-buttons.scss'
 export const CoverButtons: React.FC = () => {
   useTranslation()
   const user = useSelector((state: ApplicationState) => state.user)
+  const authProviders = useSelector((state: ApplicationState) => state.backendConfig.authProviders)
 
   if (user) {
     return null
@@ -17,15 +18,20 @@ export const CoverButtons: React.FC = () => {
 
   return (
     <div className="mb-5">
-      <SignInButton
-        className="cover-button"
-        variant="success"
-        size="lg"
-      />
-
-      <span className="m-2">
-        <Trans i18nKey="common.or"/>
-      </span>
+      {
+        Object.values(authProviders).includes(true)
+          ? <Fragment>
+            <SignInButton
+               className="cover-button"
+               variant="success"
+              size="lg"
+            />
+            <span className="m-2">
+              <Trans i18nKey="common.or"/>
+            </span>
+          </Fragment>
+          : null
+      }
 
       <Link to="/features">
         <Button

--- a/src/components/landing/pages/login/login.tsx
+++ b/src/components/landing/pages/login/login.tsx
@@ -18,6 +18,9 @@ export const Login: React.FC = () => {
   const ldapForm = authProviders.ldap ? <ViaLdap/> : null
   const openIdForm = authProviders.openid ? <ViaOpenId/> : null
 
+  const oneClickProviders = [authProviders.dropbox, authProviders.facebook, authProviders.github, authProviders.gitlab,
+    authProviders.google, authProviders.oauth2, authProviders.saml, authProviders.twitter]
+
   const oneClickCustomName: (type: OneClickType) => string | undefined = (type) => {
     switch (type) {
       case OneClickType.SAML:
@@ -48,30 +51,34 @@ export const Login: React.FC = () => {
             </Col>
             : null
         }
-        <Col xs={12} sm={10} lg={4}>
-          <Card className="bg-dark mb-4">
-            <Card.Body>
-              <Card.Title>
-                <Trans i18nKey="login.signInVia" values={{ service: '' }}/>
-              </Card.Title>
-              {
-                Object.values(OneClickType)
-                  .filter((value) => authProviders[value])
-                  .map((value) => (
-                    <div
-                      className="p-2 d-flex flex-column social-button-container"
-                      key={value}
-                    >
-                      <ViaOneClick
-                        oneClickType={value}
-                        optionalName={oneClickCustomName(value)}
-                      />
-                    </div>
-                  ))
-              }
-            </Card.Body>
-          </Card>
-        </Col>
+        {
+          oneClickProviders.includes(true)
+            ? <Col xs={12} sm={10} lg={4}>
+              <Card className="bg-dark mb-4">
+                <Card.Body>
+                  <Card.Title>
+                    <Trans i18nKey="login.signInVia" values={{ service: '' }}/>
+                  </Card.Title>
+                  {
+                    Object.values(OneClickType)
+                      .filter((value) => authProviders[value])
+                      .map((value) => (
+                          <div
+                            className="p-2 d-flex flex-column social-button-container"
+                            key={value}
+                          >
+                            <ViaOneClick
+                              oneClickType={value}
+                              optionalName={oneClickCustomName(value)}
+                            />
+                          </div>
+                       ))
+                  }
+                </Card.Body>
+              </Card>
+            </Col>
+            : null
+        }
       </Row>
     </div>
   )

--- a/src/components/landing/pages/login/login.tsx
+++ b/src/components/landing/pages/login/login.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Redirect } from 'react-router'
 import { ApplicationState } from '../../../../redux'
+import { ShowIf } from '../../../common/show-if'
 import { ViaEMail } from './auth/via-email'
 import { ViaLdap } from './auth/via-ldap'
 import { OneClickType, ViaOneClick } from './auth/via-one-click'
@@ -42,43 +43,39 @@ export const Login: React.FC = () => {
   return (
     <div className="my-3">
       <Row className="h-100 flex justify-content-center">
-        {
-          authProviders.email || authProviders.ldap || authProviders.openid
-            ? <Col xs={12} sm={10} lg={4}>
-              {emailForm}
-              {ldapForm}
-              {openIdForm}
-            </Col>
-            : null
-        }
-        {
-          oneClickProviders.includes(true)
-            ? <Col xs={12} sm={10} lg={4}>
-              <Card className="bg-dark mb-4">
-                <Card.Body>
-                  <Card.Title>
-                    <Trans i18nKey="login.signInVia" values={{ service: '' }}/>
-                  </Card.Title>
-                  {
-                    Object.values(OneClickType)
-                      .filter((value) => authProviders[value])
-                      .map((value) => (
-                          <div
-                            className="p-2 d-flex flex-column social-button-container"
-                            key={value}
-                          >
-                            <ViaOneClick
-                              oneClickType={value}
-                              optionalName={oneClickCustomName(value)}
-                            />
-                          </div>
-                       ))
-                  }
-                </Card.Body>
-              </Card>
-            </Col>
-            : null
-        }
+        <ShowIf condition={authProviders.email || authProviders.ldap || authProviders.openid}>
+          <Col xs={12} sm={10} lg={4}>
+            {emailForm}
+            {ldapForm}
+            {openIdForm}
+          </Col>
+        </ShowIf>
+        <ShowIf condition={oneClickProviders.includes(true)}>
+          <Col xs={12} sm={10} lg={4}>
+            <Card className="bg-dark mb-4">
+              <Card.Body>
+                <Card.Title>
+                  <Trans i18nKey="login.signInVia" values={{ service: '' }}/>
+                </Card.Title>
+                {
+                  Object.values(OneClickType)
+                    .filter((value) => authProviders[value])
+                    .map((value) => (
+                      <div
+                        className="p-2 d-flex flex-column social-button-container"
+                        key={value}
+                      >
+                        <ViaOneClick
+                          oneClickType={value}
+                          optionalName={oneClickCustomName(value)}
+                        />
+                      </div>
+                    ))
+                }
+              </Card.Body>
+            </Card>
+          </Col>
+        </ShowIf>
       </Row>
     </div>
   )


### PR DESCRIPTION
This PR fixes two login-provider related UI things:
- The login buttons showed up even if no auth-provider was enabled. They will now only be shown if at least one provider is enabled. This is ideal for "anonymous-only" instances and prevents from users seeing an empty login page.
- The "sign-in via"-box for one-click-providers showed up without content when no such providers were configured. This box will now be hidden if no one-click-providers were configured.