### PR TITLE
Add function for language code shortening

### DIFF
--- a/src/components/landing/layout/footer/language-picker.tsx
+++ b/src/components/landing/layout/footer/language-picker.tsx
@@ -13,10 +13,11 @@ const LanguagePicker: React.FC = () => {
 
   const shortenLanguageCode = ():string => {
     const language = i18n.language
-    if (language.substr(0, 2) === 'zh') {
+    const languagePart = language.substr(0, 2)
+    if (languagePart === 'zh') {
       return language
     } else {
-      return language.substr(0, 2)
+      return languagePart
     }
   }
 

--- a/src/components/landing/layout/footer/language-picker.tsx
+++ b/src/components/landing/layout/footer/language-picker.tsx
@@ -11,13 +11,12 @@ const LanguagePicker: React.FC = () => {
     await i18n.changeLanguage(event.currentTarget.value)
   }
 
-  const shortenLanguageCode = ():string => {
-    const language = i18n.language
-    const languagePart = language.substr(0, 2)
-    if (languagePart === 'zh') {
+  const shortenLanguageCode = (language: string):string => {
+    const languageWithoutArea = language.substr(0, 2)
+    if (languageWithoutArea === 'zh') {
       return language
     } else {
-      return languagePart
+      return languageWithoutArea
     }
   }
 
@@ -26,7 +25,7 @@ const LanguagePicker: React.FC = () => {
       as="select"
       size="sm"
       className="mb-2 mx-auto w-auto"
-      value={shortenLanguageCode()}
+      value={shortenLanguageCode(i18n.language)}
       onChange={onChangeLang}
     >
       <option value="en">English</option>

--- a/src/components/landing/layout/footer/language-picker.tsx
+++ b/src/components/landing/layout/footer/language-picker.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
 import moment from 'moment'
+import React from 'react'
 import { Form } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
 
 const LanguagePicker: React.FC = () => {
   const { i18n } = useTranslation()
@@ -11,12 +11,21 @@ const LanguagePicker: React.FC = () => {
     await i18n.changeLanguage(event.currentTarget.value)
   }
 
+  const shortenLanguageCode = ():string => {
+    const language = i18n.language
+    if (language.substr(0, 2) === 'zh') {
+      return language
+    } else {
+      return language.substr(0, 2)
+    }
+  }
+
   return (
     <Form.Control
       as="select"
       size="sm"
       className="mb-2 mx-auto w-auto"
-      value={i18n.language}
+      value={shortenLanguageCode()}
       onChange={onChangeLang}
     >
       <option value="en">English</option>

--- a/src/components/landing/layout/footer/language-picker.tsx
+++ b/src/components/landing/layout/footer/language-picker.tsx
@@ -11,7 +11,7 @@ const LanguagePicker: React.FC = () => {
     await i18n.changeLanguage(event.currentTarget.value)
   }
 
-  const shortenLanguageCode = (language: string):string => {
+  const shortenLanguageCode = (language: string): string => {
     const languageWithoutArea = language.substr(0, 2)
     if (languageWithoutArea === 'zh') {
       return language


### PR DESCRIPTION
The browser is sending the combined language Code `language-Area`, but our language file names don't contain the area.
This PR adds a function, that removes the Area from the provided language code.

Fixes #155