### PR TITLE
fix internal link

### DIFF
--- a/src/components/links/internal-link.tsx
+++ b/src/components/links/internal-link.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment } from 'react'
-import { LinkContainer } from 'react-router-bootstrap'
+import { Link } from 'react-router-dom'
 import { ForkAwesomeIcon } from '../../fork-awesome/fork-awesome-icon'
 import { LinkWithTextProps } from './types'
 
 export const InternalLink: React.FC<LinkWithTextProps> = ({ href, text, icon, className = 'text-light' }) => {
   return (
-    <LinkContainer to={href}
+    <Link to={href}
       className={className}>
       <Fragment>
         {
@@ -17,6 +17,6 @@ export const InternalLink: React.FC<LinkWithTextProps> = ({ href, text, icon, cl
         }
         {text}
       </Fragment>
-    </LinkContainer>
+    </Link>
   )
 }


### PR DESCRIPTION
internal links now use the Link component instead of the LinkContainer component, because the later is intended for use with react-bootstrap components and not for simple translated strings. This misuse made the Releases link in the footer of the landing page non-clickable in master…

Signed-off-by: Philip Molares <philip.molares@udo.edu>