### PR TITLE
Add links from recent note history entries to the actual note

### DIFF
--- a/src/components/landing/pages/history/history-card/history-card.tsx
+++ b/src/components/landing/pages/history/history-card/history-card.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment'
 import React from 'react'
 import { Badge, Card } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
 import { formatHistoryDate } from '../../../../../utils/historyUtils'
 import { ForkAwesomeIcon } from '../../../../common/fork-awesome/fork-awesome-icon'
 import { EntryMenu } from '../common/entry-menu'
@@ -11,36 +12,38 @@ import './history-card.scss'
 export const HistoryCard: React.FC<HistoryEntryProps> = ({ entry, onPinClick, onRemoveClick }) => {
   return (
     <div className="p-2 col-xs-12 col-sm-6 col-md-6 col-lg-4">
-      <Card className="card-min-height" text={'dark'} bg={'light'}>
-        <Card.Body className="p-2 d-flex flex-row justify-content-between">
-          <div className={'d-flex flex-column'}>
-            <PinButton isDark={false} isPinned={entry.pinned} onPinClick={() => onPinClick(entry.id, entry.location)}/>
-          </div>
-          <div className={'d-flex flex-column justify-content-between'}>
-            <Card.Title className="m-0 mt-1dot5">{entry.title}</Card.Title>
-            <div>
-              <div className="text-black-50 mt-2">
-                <ForkAwesomeIcon icon="clock-o"/> {moment(entry.lastVisited).fromNow()}<br/>
-                {formatHistoryDate(entry.lastVisited)}
-              </div>
-              <div className={'card-footer-min-height p-0'}>
-                {
-                  entry.tags.map((tag) => <Badge variant={'dark'} className={'mr-1 mb-1'} key={tag}>{tag}</Badge>)
-                }
+      <Link to={`/n/${entry.id}`} className="text-decoration-none">
+        <Card className="card-min-height" text={'dark'} bg={'light'}>
+          <Card.Body className="p-2 d-flex flex-row justify-content-between">
+            <div className={'d-flex flex-column'}>
+              <PinButton isDark={false} isPinned={entry.pinned} onPinClick={() => onPinClick(entry.id, entry.location)}/>
+            </div>
+            <div className={'d-flex flex-column justify-content-between'}>
+              <Card.Title className="m-0 mt-1dot5">{entry.title}</Card.Title>
+              <div>
+                <div className="text-black-50 mt-2">
+                  <ForkAwesomeIcon icon="clock-o"/> {moment(entry.lastVisited).fromNow()}<br/>
+                  {formatHistoryDate(entry.lastVisited)}
+                </div>
+                <div className={'card-footer-min-height p-0'}>
+                  {
+                    entry.tags.map((tag) => <Badge variant={'dark'} className={'mr-1 mb-1'} key={tag}>{tag}</Badge>)
+                  }
+                </div>
               </div>
             </div>
-          </div>
-          <div className={'d-flex flex-column'}>
-            <EntryMenu
-              id={entry.id}
-              location={entry.location}
-              isDark={false}
-              onRemove={() => onRemoveClick(entry.id, entry.location)}
-              onDelete={() => onRemoveClick(entry.id, entry.location)}
-            />
-          </div>
-        </Card.Body>
-      </Card>
+            <div className={'d-flex flex-column'}>
+              <EntryMenu
+                id={entry.id}
+                location={entry.location}
+                isDark={false}
+                onRemove={() => onRemoveClick(entry.id, entry.location)}
+                onDelete={() => onRemoveClick(entry.id, entry.location)}
+              />
+            </div>
+          </Card.Body>
+        </Card>
+      </Link>
     </div>
   )
 }

--- a/src/components/landing/pages/history/history-card/history-card.tsx
+++ b/src/components/landing/pages/history/history-card/history-card.tsx
@@ -12,12 +12,12 @@ import './history-card.scss'
 export const HistoryCard: React.FC<HistoryEntryProps> = ({ entry, onPinClick, onRemoveClick }) => {
   return (
     <div className="p-2 col-xs-12 col-sm-6 col-md-6 col-lg-4">
-      <Link to={`/n/${entry.id}`} className="text-decoration-none">
-        <Card className="card-min-height" text={'dark'} bg={'light'}>
-          <Card.Body className="p-2 d-flex flex-row justify-content-between">
-            <div className={'d-flex flex-column'}>
-              <PinButton isDark={false} isPinned={entry.pinned} onPinClick={() => onPinClick(entry.id, entry.location)}/>
-            </div>
+      <Card className="card-min-height" text={'dark'} bg={'light'}>
+        <Card.Body className="p-2 d-flex flex-row justify-content-between">
+          <div className={'d-flex flex-column'}>
+            <PinButton isDark={false} isPinned={entry.pinned} onPinClick={() => onPinClick(entry.id, entry.location)}/>
+          </div>
+          <Link to={`/n/${entry.id}`} className="text-decoration-none flex-fill text-dark">
             <div className={'d-flex flex-column justify-content-between'}>
               <Card.Title className="m-0 mt-1dot5">{entry.title}</Card.Title>
               <div>
@@ -32,18 +32,18 @@ export const HistoryCard: React.FC<HistoryEntryProps> = ({ entry, onPinClick, on
                 </div>
               </div>
             </div>
-            <div className={'d-flex flex-column'}>
-              <EntryMenu
-                id={entry.id}
-                location={entry.location}
-                isDark={false}
-                onRemove={() => onRemoveClick(entry.id, entry.location)}
-                onDelete={() => onRemoveClick(entry.id, entry.location)}
-              />
-            </div>
-          </Card.Body>
-        </Card>
-      </Link>
+          </Link>
+          <div className={'d-flex flex-column'}>
+            <EntryMenu
+              id={entry.id}
+              location={entry.location}
+              isDark={false}
+              onRemove={() => onRemoveClick(entry.id, entry.location)}
+              onDelete={() => onRemoveClick(entry.id, entry.location)}
+            />
+          </div>
+        </Card.Body>
+      </Card>
     </div>
   )
 }

--- a/src/components/landing/pages/history/history-table/history-table-row.tsx
+++ b/src/components/landing/pages/history/history-table/history-table-row.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Badge } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
 import { formatHistoryDate } from '../../../../../utils/historyUtils'
 import { EntryMenu } from '../common/entry-menu'
 import { PinButton } from '../common/pin-button'
@@ -8,7 +9,11 @@ import { HistoryEntryProps } from '../history-content/history-content'
 export const HistoryTableRow: React.FC<HistoryEntryProps> = ({ entry, onPinClick, onRemoveClick }) => {
   return (
     <tr>
-      <td>{entry.title}</td>
+      <td>
+        <Link to={`/n/${entry.id}`} className="text-light">
+          {entry.title}
+        </Link>
+      </td>
       <td>{formatHistoryDate(entry.lastVisited)}</td>
       <td>
         {


### PR DESCRIPTION
This PR adds Links to the cards and table rows of the recent notes history for accessing the actual note of the history entry.
This PR also includes a small fix for the improper display of the dropdown-toggle in the actions column of the history table-view.

Before merging this PR the code needs to be adjusted so that the dropdown-toggle and pin icon on the history cards become clickable again!

Fixes #202 