### PR TITLE
added support for markdown-it-footnote

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "markdown-it-emoji": "1.4.0",
     "markdown-it-ins": "^3.0.0",
     "markdown-it-mark": "^3.0.0",
+    "markdown-it-footnote": "^3.0.2",
     "markdown-it-regex": "0.2.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",

--- a/src/components/editor/markdown-preview/markdown-preview.tsx
+++ b/src/components/editor/markdown-preview/markdown-preview.tsx
@@ -9,6 +9,7 @@ import markdownItRegex from 'markdown-it-regex'
 import subscript from 'markdown-it-sub'
 import superscript from 'markdown-it-sup'
 import taskList from 'markdown-it-task-lists'
+import footnote from 'markdown-it-footnote'
 import React, { ReactElement, useMemo } from 'react'
 import ReactHtmlParser, { convertNodeToElement, Transform } from 'react-html-parser'
 import { createRenderContainer, validAlertLevels } from './container-plugins/alert'
@@ -49,6 +50,7 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content }) => {
     md.use(superscript)
     md.use(inserted)
     md.use(marked)
+    md.use(footnote)
     md.use(markdownItRegex, replaceLegacyYoutubeShortCode)
     md.use(markdownItRegex, replaceLegacyVimeoShortCode)
     md.use(markdownItRegex, replaceLegacyGistShortCode)

--- a/src/external-types/markdown-it-footnote/index.d.ts
+++ b/src/external-types/markdown-it-footnote/index.d.ts
@@ -1,0 +1,6 @@
+
+declare module 'markdown-it-footnote' {
+  import MarkdownIt from 'markdown-it/lib'
+  const markdownItFootnote: MarkdownIt.PluginSimple
+  export = markdownItFootnote
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7307,6 +7307,11 @@ markdown-it-mark@^3.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-3.0.0.tgz#27c3e39ef3cc310b2dde5375082c9fa912983cda"
   integrity sha512-HqMWeKfMMOu4zBO0emmxsoMWmbf2cPKZY1wP6FsTbKmicFfp5y4L3KXAsNeO1rM6NTJVOrNlLKMPjWzriBGspw==
 
+markdown-it-footnote@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz#1575ee7a093648d4e096aa33386b058d92ac8bc1"
+  integrity sha512-JVW6fCmZWjvMdDQSbOT3nnOQtd9iAXmw7hTSh26+v42BnvXeVyGMDBm5b/EZocMed2MbCAHiTX632vY0FyGB8A==
+
 markdown-it-regex@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/markdown-it-regex/-/markdown-it-regex-0.2.0.tgz#e09ad2d75209720d591d3949e1142c75c0fbecf6"


### PR DESCRIPTION
### Component/Part
markdown renderer

### Description
This PR makes it possible to use footnotes

![grafik](https://user-images.githubusercontent.com/3978662/85205784-cf34f800-b31d-11ea-948b-fde4e158ac26.png)


### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
<!-- e.g #123 -->
