### PR TITLE
Fixed ToC only showing up to 2 levels instead of 3

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -86,6 +86,7 @@ const MarkdownRenderer: React.FC<MarkdownPreviewProps> = ({ content }) => {
       permalinkSymbol: '<i class="fa fa-link"></i>'
     })
     md.use(toc, {
+      includeLevel: [1, 2, 3],
       markerPattern: /^\[TOC]$/i
     })
     md.use(mathJax({


### PR DESCRIPTION
### Component/Part
Markdown renderer of editor

### Description
This PR fixes the bug that only up to 2 levels of heading were shown in the generated ToC. It's a simple matter of configuration and now the behavior is like in 1.6 again.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
Fixes #256 
