### PR TITLE
Added image resizing support via markdown-it-imsize

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "markdown-it-deflist": "2.0.3",
     "markdown-it-emoji": "1.4.0",
     "markdown-it-footnote": "3.0.2",
+    "markdown-it-imsize": "^2.0.1",
     "markdown-it-ins": "3.0.0",
     "markdown-it-mark": "3.0.0",
     "markdown-it-mathjax": "^2.0.0",

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -6,6 +6,7 @@ import markdownItContainer from 'markdown-it-container'
 import definitionList from 'markdown-it-deflist'
 import emoji from 'markdown-it-emoji'
 import footnote from 'markdown-it-footnote'
+import imsize from 'markdown-it-imsize'
 import inserted from 'markdown-it-ins'
 import marked from 'markdown-it-mark'
 import markdownItRegex from 'markdown-it-regex'
@@ -78,6 +79,7 @@ const MarkdownRenderer: React.FC<MarkdownPreviewProps> = ({ content }) => {
     md.use(inserted)
     md.use(marked)
     md.use(footnote)
+    md.use(imsize)
     // noinspection CheckTagEmptyBody
     md.use(anchor, {
       permalink: true,

--- a/src/external-types/markdown-it-imsize/index.d.ts
+++ b/src/external-types/markdown-it-imsize/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'markdown-it-imsize' {
+  import MarkdownIt from 'markdown-it/lib'
+  import { ImsizeOptions } from './interface'
+  const markdownItImsize: MarkdownIt.PluginWithOptions<ImsizeOptions>
+  export = markdownItImsize
+}

--- a/src/external-types/markdown-it-imsize/interface.ts
+++ b/src/external-types/markdown-it-imsize/interface.ts
@@ -1,0 +1,3 @@
+export interface ImsizeOptions {
+  autofill?: boolean
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7336,6 +7336,11 @@ markdown-it-footnote@3.0.2:
   resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz#1575ee7a093648d4e096aa33386b058d92ac8bc1"
   integrity sha512-JVW6fCmZWjvMdDQSbOT3nnOQtd9iAXmw7hTSh26+v42BnvXeVyGMDBm5b/EZocMed2MbCAHiTX632vY0FyGB8A==
 
+markdown-it-imsize@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
+  integrity sha1-zKBCeQXQUziiR8ucqdloxc3dUXA=
+
 markdown-it-ins@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-ins/-/markdown-it-ins-3.0.0.tgz#b1b56824c78dc66e52b0fc97531b317cd78d79d2"


### PR DESCRIPTION
### Component/Part
Markdown renderer of the editor

### Description
This PR adds support for the image resizing syntax: `![](https://dummyimage.com/96 =48x48)`.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
Closes #259 
