### PR TITLE
Add spaces to highlighted code regex

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-it-plugins/highlighted-code.ts
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/highlighted-code.ts
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it/lib'
 
-const highlightRegex = /^(\w*)(=(\d*|\+))?(!?)$/
+const highlightRegex = /^ *(\w*)(=(\d*|\+))?(!?)$/
 
 export const highlightedCode: MarkdownIt.PluginSimple = (md: MarkdownIt) => {
   md.core.ruler.push('highlighted-code', (state) => {


### PR DESCRIPTION
### Component/Part
Code block highlightning

### Description
This PR improves the code highlight regex by allowing spaces before the language name.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog
