### PR TITLE
added image-replacer

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -38,6 +38,7 @@ import { replaceYouTubeLink } from './regex-plugins/replace-youtube-link'
 import { ComponentReplacer, SubNodeConverter } from './replace-components/ComponentReplacer'
 import { GistReplacer } from './replace-components/gist/gist-replacer'
 import { HighlightedCodeReplacer } from './replace-components/highlighted-fence/highlighted-fence-replacer'
+import { ImageReplacer } from './replace-components/image/image-replacer'
 import { MathjaxReplacer } from './replace-components/mathjax/mathjax-replacer'
 import { PdfReplacer } from './replace-components/pdf/pdf-replacer'
 import { QuoteOptionsReplacer } from './replace-components/quote-options/quote-options-replacer'
@@ -123,6 +124,7 @@ const MarkdownRenderer: React.FC<MarkdownPreviewProps> = ({ content }) => {
       new YoutubeReplacer(),
       new VimeoReplacer(),
       new PdfReplacer(),
+      new ImageReplacer(),
       new TocReplacer(),
       new HighlightedCodeReplacer(),
       new QuoteOptionsReplacer(),

--- a/src/components/editor/markdown-renderer/replace-components/image/image-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/image/image-frame.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export interface ImageFrameProps {
+  src: string
+  className?: string
+  id?: string
+  alt?: string
+  width?: string
+  height?: string
+}
+
+export const ImageFrame: React.FC<ImageFrameProps> = ({ src, className, id, alt, width, height }) => {
+  return (
+    <img
+      id={id}
+      className={className}
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+    />
+  )
+}

--- a/src/components/editor/markdown-renderer/replace-components/image/image-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/image/image-frame.tsx
@@ -1,23 +1,7 @@
 import React from 'react'
 
-export interface ImageFrameProps {
-  src: string
-  className?: string
-  id?: string
-  alt?: string
-  width?: string
-  height?: string
-}
-
-export const ImageFrame: React.FC<ImageFrameProps> = ({ src, className, id, alt, width, height }) => {
+export const ImageFrame: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = ({alt, ...props}) => {
   return (
-    <img
-      id={id}
-      className={className}
-      src={src}
-      alt={alt}
-      width={width}
-      height={height}
-    />
+    <img alt={alt} {...props}/>
   )
 }

--- a/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
@@ -13,7 +13,10 @@ export class ImageReplacer implements ComponentReplacer {
         id={node.attribs.id}
         className={node.attribs.class}
         src={node.attribs.src}
-        alt={node.attribs.alt}/>
+        alt={node.attribs.alt}
+        width={node.attribs.width}
+        height={node.attribs.height}
+      />
     }
   }
 }

--- a/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
@@ -5,10 +5,7 @@ import { ImageFrame } from './image-frame'
 
 export class ImageReplacer implements ComponentReplacer {
   getReplacement (node: DomElement): React.ReactElement | undefined {
-    if (node.name === 'img' &&
-      node.attribs &&
-      node.attribs.src) {
-      // single image in <p>
+    if (node.name === 'img' && node.attribs) {
       return <ImageFrame
         id={node.attribs.id}
         className={node.attribs.class}

--- a/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/image/image-replacer.tsx
@@ -1,0 +1,19 @@
+import { DomElement } from 'domhandler'
+import React from 'react'
+import { ComponentReplacer } from '../ComponentReplacer'
+import { ImageFrame } from './image-frame'
+
+export class ImageReplacer implements ComponentReplacer {
+  getReplacement (node: DomElement): React.ReactElement | undefined {
+    if (node.name === 'img' &&
+      node.attribs &&
+      node.attribs.src) {
+      // single image in <p>
+      return <ImageFrame
+        id={node.attribs.id}
+        className={node.attribs.class}
+        src={node.attribs.src}
+        alt={node.attribs.alt}/>
+    }
+  }
+}


### PR DESCRIPTION
### Component/Part
markdown renderer

### Description
This PR replaces all <img>'s in the markdown-it output with an ImageFrame component. This enables us to implement image proxies and other per image customization in the future.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
closes #264
