### PR TITLE
Added click-to-load text for pdf embeddings and general option for texts on the embedding preview

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -254,6 +254,9 @@
                 "question": "Do you really want to delete this note?",
                 "warning": "All users will lose their connection."
             }
+        },
+        "embeddings": {
+          "clickToLoad": "Click to load"
         }
     },
     "common":  {

--- a/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.scss
+++ b/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.scss
@@ -17,7 +17,7 @@
     text-shadow: #000000 0 0 5px;
   }
 
-  &:hover > i {
+  &:hover > .one-click-embedding-icon {
     opacity: 0.8;
     text-shadow: #000000 0 0 10px;
   }

--- a/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
@@ -8,7 +8,7 @@ interface OneClickFrameProps {
   onImageFetch?: () => Promise<string>
   loadingImageUrl: string
   hoverIcon?: IconName
-  hoverTextLocalized?: string
+  hoverTextI18nKey?: string
   tooltip?: string
   containerClassName?: string
   previewContainerClassName?: string
@@ -17,7 +17,7 @@ interface OneClickFrameProps {
 
 }
 
-export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, hoverTextLocalized, onActivate }) => {
+export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, hoverTextI18nKey, onActivate }) => {
   const [showFrame, setShowFrame] = useState(false)
   const [previewImageLink, setPreviewImageLink] = useState<string>(loadingImageUrl)
 
@@ -50,9 +50,9 @@ export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContain
           <ShowIf condition={!!hoverIcon}>
             <span className='one-click-embedding-icon text-center'>
               <i className={`fa fa-${hoverIcon as string} fa-5x mb-2`} />
-              <ShowIf condition={hoverTextLocalized !== undefined}>
+              <ShowIf condition={hoverTextI18nKey !== undefined}>
                 <br />
-                <Trans i18nKey={hoverTextLocalized} />
+                <Trans i18nKey={hoverTextI18nKey} />
               </ShowIf>
             </span>
           </ShowIf>

--- a/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
@@ -15,8 +15,6 @@ interface OneClickFrameProps {
   onActivate?: () => void
 }
 
-}
-
 export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, hoverTextI18nKey, onActivate }) => {
   const [showFrame, setShowFrame] = useState(false)
   const [previewImageLink, setPreviewImageLink] = useState<string>(loadingImageUrl)

--- a/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
@@ -6,7 +6,7 @@ import './one-click-embedding.scss'
 
 interface OneClickFrameProps {
   onImageFetch?: () => Promise<string>
-  loadingImageUrl: string
+  loadingImageUrl?: string
   hoverIcon?: IconName
   hoverTextI18nKey?: string
   tooltip?: string
@@ -17,7 +17,7 @@ interface OneClickFrameProps {
 
 export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, hoverTextI18nKey, onActivate }) => {
   const [showFrame, setShowFrame] = useState(false)
-  const [previewImageLink, setPreviewImageLink] = useState<string>(loadingImageUrl)
+  const [previewImageUrl, setPreviewImageUrl] = useState(loadingImageUrl)
 
   const showChildren = () => {
     setShowFrame(true)
@@ -31,7 +31,7 @@ export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContain
       return
     }
     onImageFetch().then((imageLink) => {
-      setPreviewImageLink(imageLink)
+      setPreviewImageUrl(imageLink)
     }).catch((message) => {
       console.error(message)
     })
@@ -44,11 +44,13 @@ export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContain
       </ShowIf>
       <ShowIf condition={!showFrame}>
         <span className={`one-click-embedding ${previewContainerClassName || ''}`} onClick={showChildren}>
-          <img className={'one-click-embedding-preview'} src={previewImageLink} alt={tooltip || ''} title={tooltip || ''}/>
+          <ShowIf condition={!!previewImageUrl}>
+            <img className={'one-click-embedding-preview'} src={previewImageUrl} alt={tooltip || ''} title={tooltip || ''}/>
+          </ShowIf>
           <ShowIf condition={!!hoverIcon}>
             <span className='one-click-embedding-icon text-center'>
               <i className={`fa fa-${hoverIcon as string} fa-5x mb-2`} />
-              <ShowIf condition={hoverTextI18nKey !== undefined}>
+              <ShowIf condition={!!hoverTextI18nKey}>
                 <br />
                 <Trans i18nKey={hoverTextI18nKey} />
               </ShowIf>

--- a/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { Trans } from 'react-i18next'
 import { IconName } from '../../../../common/fork-awesome/fork-awesome-icon'
 import { ShowIf } from '../../../../common/show-if/show-if'
 import './one-click-embedding.scss'
@@ -7,13 +8,16 @@ interface OneClickFrameProps {
   onImageFetch?: () => Promise<string>
   loadingImageUrl: string
   hoverIcon?: IconName
+  hoverTextLocalized?: string
   tooltip?: string
   containerClassName?: string
   previewContainerClassName?: string
   onActivate?: () => void
 }
 
-export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, onActivate }) => {
+}
+
+export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContainerClassName, containerClassName, onImageFetch, loadingImageUrl, children, tooltip, hoverIcon, hoverTextLocalized, onActivate }) => {
   const [showFrame, setShowFrame] = useState(false)
   const [previewImageLink, setPreviewImageLink] = useState<string>(loadingImageUrl)
 
@@ -44,7 +48,13 @@ export const OneClickEmbedding: React.FC<OneClickFrameProps> = ({ previewContain
         <span className={`one-click-embedding ${previewContainerClassName || ''}`} onClick={showChildren}>
           <img className={'one-click-embedding-preview'} src={previewImageLink} alt={tooltip || ''} title={tooltip || ''}/>
           <ShowIf condition={!!hoverIcon}>
-            <i className={`one-click-embedding-icon fa fa-${hoverIcon as string} fa-5x`}/>
+            <span className='one-click-embedding-icon text-center'>
+              <i className={`fa fa-${hoverIcon as string} fa-5x mb-2`} />
+              <ShowIf condition={hoverTextLocalized !== undefined}>
+                <br />
+                <Trans i18nKey={hoverTextLocalized} />
+              </ShowIf>
+            </span>
           </ShowIf>
         </span>
       </ShowIf>

--- a/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
@@ -15,7 +15,6 @@ export const PdfFrame: React.FC<PdfFrameProps> = ({ url }) => {
       previewContainerClassName={'embed-responsive-item bg-danger'}
       hoverIcon={'file-pdf-o'}
       hoverTextI18nKey={'editor.embeddings.clickToLoad'}
-      loadingImageUrl={''}
       onActivate={() => setActivated(true)}>
       <object type={'application/pdf'} data={url} className={'pdf-frame'}>
         <ExternalLink text={url} href={url}/>

--- a/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
@@ -14,7 +14,7 @@ export const PdfFrame: React.FC<PdfFrameProps> = ({ url }) => {
     <OneClickEmbedding containerClassName={`embed-responsive embed-responsive-${activated ? '4by3' : '16by9'`}
       previewContainerClassName={'embed-responsive-item bg-danger'}
       hoverIcon={'file-pdf-o'}
-      hoverTextLocalized={'editor.embeddings.clickToLoad'}
+      hoverTextI18nKey={'editor.embeddings.clickToLoad'}
       loadingImageUrl={''}
       onActivate={() => setActivated(true)}>
       <object type={'application/pdf'} data={url} className={'pdf-frame'}>

--- a/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
@@ -11,9 +11,12 @@ export const PdfFrame: React.FC<PdfFrameProps> = ({ url }) => {
   const [activated, setActivated] = useState(false)
 
   return (
-    <OneClickEmbedding containerClassName={`embed-responsive embed-responsive-${activated ? '4by3' : '16by9'}`}
-      previewContainerClassName={'embed-responsive-item bg-danger'} hoverIcon={'file-pdf-o'}
-      loadingImageUrl={''} onActivate={() => setActivated(true)}>
+    <OneClickEmbedding containerClassName={`embed-responsive embed-responsive-${activated ? '4by3' : '16by9'`}
+      previewContainerClassName={'embed-responsive-item bg-danger'}
+      hoverIcon={'file-pdf-o'}
+      hoverTextLocalized={'editor.embeddings.clickToLoad'}
+      loadingImageUrl={''}
+      onActivate={() => setActivated(true)}>
       <object type={'application/pdf'} data={url} className={'pdf-frame'}>
         <ExternalLink text={url} href={url}/>
       </object>

--- a/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/pdf/pdf-frame.tsx
@@ -11,7 +11,7 @@ export const PdfFrame: React.FC<PdfFrameProps> = ({ url }) => {
   const [activated, setActivated] = useState(false)
 
   return (
-    <OneClickEmbedding containerClassName={`embed-responsive embed-responsive-${activated ? '4by3' : '16by9'`}
+    <OneClickEmbedding containerClassName={`embed-responsive embed-responsive-${activated ? '4by3' : '16by9'}`}
       previewContainerClassName={'embed-responsive-item bg-danger'}
       hoverIcon={'file-pdf-o'}
       hoverTextI18nKey={'editor.embeddings.clickToLoad'}


### PR DESCRIPTION
### Component/Part
Markdown renderer

### Description
This PR adds the possibility to add a text below the icon on the embedding preview.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
none

### Screenshot
![image](https://user-images.githubusercontent.com/52606896/85788578-80c49680-b72d-11ea-87bc-25427d6edebc.png)

