### PR TITLE
Fixed bug that two p-tags were encapsulated inside each other

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -52,7 +52,7 @@ export interface MarkdownPreviewProps {
   wide?: boolean
 }
 
-const createMarkdownIt = ():MarkdownIt => {
+const createMarkdownIt = (): MarkdownIt => {
   const md = new MarkdownIt('default', {
     html: true,
     breaks: true,

--- a/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
@@ -17,10 +17,7 @@ export class PossibleWiderReplacer implements ComponentReplacer {
     if (!(childIsImage || childIsYoutube || childIsVimeo || childIsPDF)) {
       return
     }
-    if (!node.attribs) {
-      return
-    }
-    node.attribs.class = `wider-possible ${node.attribs.class || ''}`
+    node.attribs = Object.assign(node.attribs || {}, { class: `wider-possible ${node.attribs?.class || ''}` })
     return subNodeConverter(node, index)
   }
 }

--- a/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
@@ -20,9 +20,7 @@ export class PossibleWiderReplacer implements ComponentReplacer {
     if (!node.attribs) {
       return
     }
-    console.log(node)
     node.attribs.class = `wider-possible ${node.attribs.class || ''}`
-
     return subNodeConverter(node, index)
   }
 }

--- a/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
@@ -17,8 +17,12 @@ export class PossibleWiderReplacer implements ComponentReplacer {
     if (!(childIsImage || childIsYoutube || childIsVimeo || childIsPDF)) {
       return
     }
-    return (<p className='wider-possible'>
-      {subNodeConverter(node, index)}
-    </p>)
+    if (!node.attribs) {
+      return
+    }
+    console.log(node)
+    node.attribs.class = `wider-possible ${node.attribs.class || ''}`
+
+    return subNodeConverter(node, index)
   }
 }

--- a/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
+++ b/src/components/editor/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
@@ -17,6 +17,8 @@ export class PossibleWiderReplacer implements ComponentReplacer {
     if (!(childIsImage || childIsYoutube || childIsVimeo || childIsPDF)) {
       return
     }
+
+    // This appends the 'wider-possible' class to the node for a wider view in view-mode
     node.attribs = Object.assign(node.attribs || {}, { class: `wider-possible ${node.attribs?.class || ''}` })
     return subNodeConverter(node, index)
   }


### PR DESCRIPTION
### Component/Part
Markdown renderer

### Description
This PR fixes a bug that two p-tags were encapsulated inside each other with the same key.
This bug was introduced because the wider-possible-replacer replaced each element that was subject to be enlarged with a brand new p-surrounding. That surrounding got the key of the old (now inner) element and therefore casts a duplicate key exception.
This fix solves that problem by setting the 'wider-possible' class attribute directly on the selected tag instead of creating a surrounding.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
none
