### PR TITLE
clarified comment in renderer CSS

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-renderer.scss
+++ b/src/components/editor/markdown-renderer/markdown-renderer.scss
@@ -7,7 +7,7 @@
     margin-bottom: 0;
   }
 
-  // I know this is bad :( sry
+  // This is necessary since we need to set this for all DOM Element that could be children of .markdown-body and since we support all of HTML that would literally be everything
   & > * {
     width: 100%;
     max-width: 900px;


### PR DESCRIPTION
### Component/Part
markdown render css

### Description
This PR changed a comment in `markdown-renderer.scss` to explain why the usage of `*` is necessary

see https://github.com/codimd/react-client/pull/271#pullrequestreview-437942115

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog
