### PR TITLE
Updated test-class matching rule of renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,8 +29,10 @@
       ]
     },
     {
-      "extends": "packages:jsTest",
-      "groupName": "JS test packages"
+      "groupName": "JS test packages",
+      "packagePatterns": [
+        "^@testing-library/"
+      ]
     }
   ],
   "prHourlyLimit": 0,


### PR DESCRIPTION
### Component/Part
The renovate bot

### Description
As seen in multiple PRs that renovate raised today, the @testing-library/ packages are not bundled in the 'packages:jsTest' pre-defined group. As they aren't relevant to be separated, this PR changes the config of renovate to treat them as one big PR in the future.