### PR TITLE
Replace links to /features with /n/features

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -133,7 +133,7 @@
         }
     },
     "editor": {
-        "placeholder": "← Start by entering a title here\n===\nVisit /features if you don't know what to do.\nHappy hacking :)",
+        "placeholder": "← Start by entering a title here\n===\nVisit /n/features if you don't know what to do.\nHappy hacking :)",
         "help": {
             "contacts": {
                 "title": "Contacts",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -133,7 +133,7 @@
         }
     },
     "editor": {
-        "placeholder": "← Start by entering a title here\n===\nVisit /n/features if you don't know what to do.\nHappy hacking :)",
+        "placeholder": "← Start by entering a title here\n===\nVisit the features page if you don't know what to do.\nHappy hacking :)",
         "help": {
             "contacts": {
                 "title": "Contacts",

--- a/src/components/landing/layout/navigation/user-dropdown/user-dropdown.tsx
+++ b/src/components/landing/layout/navigation/user-dropdown/user-dropdown.tsx
@@ -23,7 +23,7 @@ export const UserDropdown: React.FC = () => {
       </Dropdown.Toggle>
 
       <Dropdown.Menu className='text-start'>
-        <LinkContainer to={'/features'}>
+        <LinkContainer to={'/n/features'}>
           <Dropdown.Item dir='auto'>
             <ForkAwesomeIcon icon="bolt" fixedWidth={true} className="mx-2"/>
             <Trans i18nKey="editor.help.documents.features"/>

--- a/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
+++ b/src/components/landing/pages/intro/cover-buttons/cover-buttons.tsx
@@ -29,7 +29,7 @@ export const CoverButtons: React.FC = () => {
           <Trans i18nKey="common.or"/>
         </span>
       </ShowIf>
-      <Link to="/features">
+      <Link to="/n/features">
         <Button
           className="cover-button"
           variant="primary"

--- a/src/components/landing/pages/intro/feature-links.tsx
+++ b/src/components/landing/pages/intro/feature-links.tsx
@@ -9,7 +9,7 @@ export const FeatureLinks: React.FC = () => {
   return (
     <Row className="mb-5">
       <Col md={4}>
-        <Link to={'/features#Share-Notes'} className="text-light">
+        <Link to={'/n/features#Share-Notes'} className="text-light">
           <ForkAwesomeIcon icon="bolt" size="3x"/>
           <h5>
             <Trans i18nKey="landing.intro.features.collaboration"/>
@@ -17,7 +17,7 @@ export const FeatureLinks: React.FC = () => {
         </Link>
       </Col>
       <Col md={4}>
-        <Link to={'/features#MathJax'} className="text-light">
+        <Link to={'/n/features#MathJax'} className="text-light">
           <ForkAwesomeIcon icon="bar-chart" size="3x"/>
           <h5>
             <Trans i18nKey="landing.intro.features.mathJax"/>
@@ -25,7 +25,7 @@ export const FeatureLinks: React.FC = () => {
         </Link>
       </Col>
       <Col md={4}>
-        <Link to={'/features#Slide-Mode'} className="text-light">
+        <Link to={'/n/features#Slide-Mode'} className="text-light">
           <ForkAwesomeIcon icon="television" size="3x"/>
           <h5>
             <Trans i18nKey="landing.intro.features.slides"/>


### PR DESCRIPTION
### Component/Part
Links in the landing page

### Description
It was discussed and agreed that all notes should reside under the /n/ namespace in the future. Even if we want to redirect all pre-2.0-notes from the root namespace to the /n/ namespace, it might be better to set the internal links for the features page properly instead on relying on the redirect.
This PR therefore replaces each occurence of `/features` with `/n/features`.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
none
