### PR TITLE
Add plantuml support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "markdown-it-ins": "3.0.0",
     "markdown-it-mark": "3.0.0",
     "markdown-it-mathjax": "2.0.0",
-    "markdown-it-plantuml": "^1.4.1",
+    "markdown-it-plantuml": "1.4.1",
     "markdown-it-regex": "0.2.0",
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "markdown-it-ins": "3.0.0",
     "markdown-it-mark": "3.0.0",
     "markdown-it-mathjax": "2.0.0",
+    "markdown-it-plantuml": "^1.4.1",
     "markdown-it-regex": "0.2.0",
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",

--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -27,6 +27,7 @@
     "saml": "aufSAMLn.de"
   },
   "useImageProxy": false,
+  "plantumlServer": "http://www.plantuml.com/plantuml",
   "specialLinks": {
     "privacy": "https://example.com/privacy",
     "termsOfUse": "https://example.com/termsOfUse",

--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -27,7 +27,10 @@
     "saml": "aufSAMLn.de"
   },
   "useImageProxy": false,
-  "plantumlServer": "http://www.plantuml.com/plantuml",
+  "plantuml": {
+    "enable": true,
+    "server": "http://www.plantuml.com/plantuml"
+  },
   "specialLinks": {
     "privacy": "https://example.com/privacy",
     "termsOfUse": "https://example.com/termsOfUse",

--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -27,9 +27,7 @@
     "saml": "aufSAMLn.de"
   },
   "useImageProxy": false,
-  "plantuml": {
-    "enable": true
-  },
+  "plantumlServer": "http://www.plantuml.com/plantuml",
   "specialLinks": {
     "privacy": "https://example.com/privacy",
     "termsOfUse": "https://example.com/termsOfUse",

--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -28,8 +28,7 @@
   },
   "useImageProxy": false,
   "plantuml": {
-    "enable": true,
-    "server": "http://www.plantuml.com/plantuml"
+    "enable": true
   },
   "specialLinks": {
     "privacy": "https://example.com/privacy",

--- a/src/api/config/types.ts
+++ b/src/api/config/types.ts
@@ -7,6 +7,7 @@ export interface Config {
   useImageProxy: boolean,
   specialLinks: SpecialLinks,
   version: BackendVersion,
+  plantumlServer: string | null,
 }
 
 export interface BrandingConfig {

--- a/src/api/config/types.ts
+++ b/src/api/config/types.ts
@@ -7,10 +7,7 @@ export interface Config {
   useImageProxy: boolean,
   specialLinks: SpecialLinks,
   version: BackendVersion,
-  plantuml: {
-    enable: boolean,
-    server: string | null,
-  },
+  plantumlServer: string | null,
 }
 
 export interface BrandingConfig {

--- a/src/api/config/types.ts
+++ b/src/api/config/types.ts
@@ -7,7 +7,10 @@ export interface Config {
   useImageProxy: boolean,
   specialLinks: SpecialLinks,
   version: BackendVersion,
-  plantumlServer: string | null,
+  plantuml: {
+    enable: boolean,
+    server: string | null,
+  },
 }
 
 export interface BrandingConfig {

--- a/src/components/editor/editorTestContent.ts
+++ b/src/components/editor/editorTestContent.ts
@@ -52,4 +52,38 @@ https://asciinema.org/a/117928
 
 let a = 1
 \`\`\`
+
+## PlantUML
+\`\`\`plantuml
+@startuml
+participant Alice
+participant "The **Famous** Bob" as Bob
+
+Alice -> Bob : hello --there--
+... Some ~~long delay~~ ...
+Bob -> Alice : ok
+note left
+  This is **bold**
+  This is //italics//
+  This is ""monospaced""
+  This is --stroked--
+  This is __underlined__
+  This is ~~waved~~
+end note
+
+Alice -> Bob : A //well formatted// message
+note right of Alice
+ This is <back:cadetblue><size:18>displayed</size></back>
+ __left of__ Alice.
+end note
+note left of Bob
+ <u:red>This</u> is <color #118888>displayed</color>
+ **<color purple>left of</color> <s:red>Alice</strike> Bob**.
+end note
+note over Alice, Bob
+ <w:#FF33FF>This is hosted</w> by <img sourceforge.jpg>
+end note
+@enduml
+\`\`\`
+
 `

--- a/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.scss
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.scss
@@ -1,0 +1,6 @@
+.plantuml-error {
+  border: #f8d5db solid 1px;
+  background-color: #fdf2f5;
+  color: #a4000f;
+  padding: .5rem;
+}

--- a/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.scss
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.scss
@@ -1,6 +1,0 @@
-.plantuml-error {
-  border: #f8d5db solid 1px;
-  background-color: #fdf2f5;
-  color: #a4000f;
-  padding: .5rem;
-}

--- a/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
@@ -1,0 +1,19 @@
+import MarkdownIt, { Options } from 'markdown-it/lib'
+import Renderer, { RenderRule } from 'markdown-it/lib/renderer'
+import Token from 'markdown-it/lib/token'
+import './plantuml-error.scss'
+
+export const plantumlError: MarkdownIt.PluginSimple = (md) => {
+  const defaultRenderer: RenderRule = md.renderer.rules.fence || (() => { return '' })
+  md.renderer.rules.fence = (tokens: Token[], idx: number, options: Options, env, slf: Renderer) => {
+    const token = tokens[idx]
+    const defaultRender = defaultRenderer(tokens, idx, options, env, slf)
+    if (token.info === 'plantuml') {
+      return `
+        <p class="plantuml-error">PlantUML plugin is enabled but not properly configured.</p>
+        ${defaultRender}
+      `
+    }
+    return defaultRender
+  }
+}

--- a/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
@@ -6,15 +6,13 @@ export const plantumlError: MarkdownIt.PluginSimple = (md) => {
   const defaultRenderer: RenderRule = md.renderer.rules.fence || (() => '')
   md.renderer.rules.fence = (tokens: Token[], idx: number, options: Options, env, slf: Renderer) => {
     const token = tokens[idx]
-    const defaultRender = defaultRenderer(tokens, idx, options, env, slf)
     if (token.info === 'plantuml') {
       return `
         <p class="alert alert-danger">
           PlantUML plugin is enabled but not properly configured.
         </p>
-        ${defaultRender}
       `
     }
-    return defaultRender
+    return defaultRenderer(tokens, idx, options, env, slf)
   }
 }

--- a/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
+++ b/src/components/editor/markdown-renderer/markdown-it-plugins/plantuml-error.ts
@@ -1,16 +1,17 @@
 import MarkdownIt, { Options } from 'markdown-it/lib'
 import Renderer, { RenderRule } from 'markdown-it/lib/renderer'
 import Token from 'markdown-it/lib/token'
-import './plantuml-error.scss'
 
 export const plantumlError: MarkdownIt.PluginSimple = (md) => {
-  const defaultRenderer: RenderRule = md.renderer.rules.fence || (() => { return '' })
+  const defaultRenderer: RenderRule = md.renderer.rules.fence || (() => '')
   md.renderer.rules.fence = (tokens: Token[], idx: number, options: Options, env, slf: Renderer) => {
     const token = tokens[idx]
     const defaultRender = defaultRenderer(tokens, idx, options, env, slf)
     if (token.info === 'plantuml') {
       return `
-        <p class="plantuml-error">PlantUML plugin is enabled but not properly configured.</p>
+        <p class="alert alert-danger">
+          PlantUML plugin is enabled but not properly configured.
+        </p>
         ${defaultRender}
       `
     }

--- a/src/components/editor/markdown-renderer/markdown-renderer.scss
+++ b/src/components/editor/markdown-renderer/markdown-renderer.scss
@@ -14,6 +14,11 @@
     max-width: 900px;
   }
 
+  & > img {
+    width: unset;
+    background-color: unset;
+  }
+
   &.wider {
     max-width: 1500px;
 

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -95,7 +95,8 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       oldFirstHeadingRef.current = firstHeadingRef.current
     }
   })
-  const plantumlServer: string | null = useSelector((state: ApplicationState) => state.backendConfig.plantumlServer)
+
+  const plantumlConfig = useSelector((state: ApplicationState) => state.config.plantuml)
 
   const markdownIt = useMemo(() => {
     const md = new MarkdownIt('default', {
@@ -131,12 +132,14 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       })
     }
     md.use(taskList)
-    if (plantumlServer) {
-      md.use(plantuml, {
-        openMarker: '```plantuml',
-        closeMarker: '```',
-        server: plantumlServer
-      })
+    if (plantumlConfig.enable) {
+      if (plantumlConfig.server) {
+        md.use(plantuml, {
+          openMarker: '```plantuml',
+          closeMarker: '```',
+          server: plantumlConfig.server
+        })
+      }
     }
     md.use(emoji)
     md.use(abbreviation)
@@ -206,7 +209,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
     })
 
     return md
-  }, [onMetaDataChange, onFirstHeadingChange, plantumlServer])
+  }, [onMetaDataChange, onFirstHeadingChange, plantumlConfig])
 
   useEffect(() => {
     if (onTocChange && tocAst && !equal(tocAst, lastTocAst)) {

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -36,6 +36,7 @@ import { highlightedCode } from './markdown-it-plugins/highlighted-code'
 import { linkifyExtra } from './markdown-it-plugins/linkify-extra'
 import { MarkdownItParserDebugger } from './markdown-it-plugins/parser-debugger'
 import './markdown-renderer.scss'
+import { plantumlError } from './markdown-it-plugins/plantuml-error'
 import { replaceAsciinemaLink } from './regex-plugins/replace-asciinema-link'
 import { replaceGistLink } from './regex-plugins/replace-gist-link'
 import { replaceLegacyGistShortCode } from './regex-plugins/replace-legacy-gist-short-code'
@@ -132,13 +133,15 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       })
     }
     md.use(taskList)
-    if (plantumlConfig.enable) {
-      if (plantumlConfig.server) {
+    if (plantumlConfig?.enable) {
+      if (plantumlConfig?.server) {
         md.use(plantuml, {
           openMarker: '```plantuml',
           closeMarker: '```',
           server: plantumlConfig.server
         })
+      } else {
+        md.use(plantumlError)
       }
     }
     md.use(emoji)

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -14,6 +14,7 @@ import inserted from 'markdown-it-ins'
 import marked from 'markdown-it-mark'
 import mathJax from 'markdown-it-mathjax'
 import markdownItRegex from 'markdown-it-regex'
+import plantuml from 'markdown-it-plantuml'
 import subscript from 'markdown-it-sub'
 import superscript from 'markdown-it-sup'
 import taskList from 'markdown-it-task-lists'
@@ -127,6 +128,11 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       })
     }
     md.use(taskList)
+    md.use(plantuml, {
+      openMarker: '```plantuml',
+      closeMarker: '```',
+      server: 'http://www.plantuml.com/plantuml'
+    })
     md.use(emoji)
     md.use(abbreviation)
     md.use(definitionList)

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -97,7 +97,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
     }
   })
 
-  const plantumlConfig = useSelector((state: ApplicationState) => state.config.plantuml)
+  const plantumlServer = useSelector((state: ApplicationState) => state.config.plantumlServer)
 
   const markdownIt = useMemo(() => {
     const md = new MarkdownIt('default', {
@@ -133,16 +133,14 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       })
     }
     md.use(taskList)
-    if (plantumlConfig?.enable) {
-      if (plantumlConfig?.server) {
-        md.use(plantuml, {
-          openMarker: '```plantuml',
-          closeMarker: '```',
-          server: plantumlConfig.server
-        })
-      } else {
-        md.use(plantumlError)
-      }
+    if (plantumlServer) {
+      md.use(plantuml, {
+        openMarker: '```plantuml',
+        closeMarker: '```',
+        server: plantumlServer
+      })
+    } else {
+      md.use(plantumlError)
     }
     md.use(emoji)
     md.use(abbreviation)
@@ -212,7 +210,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
     })
 
     return md
-  }, [onMetaDataChange, onFirstHeadingChange, plantumlConfig])
+  }, [onMetaDataChange, onFirstHeadingChange, plantumlServer])
 
   useEffect(() => {
     if (onTocChange && tocAst && !equal(tocAst, lastTocAst)) {

--- a/src/components/editor/markdown-renderer/markdown-renderer.tsx
+++ b/src/components/editor/markdown-renderer/markdown-renderer.tsx
@@ -24,7 +24,9 @@ import { Alert } from 'react-bootstrap'
 import ReactHtmlParser, { convertNodeToElement, Transform } from 'react-html-parser'
 import { Trans } from 'react-i18next'
 import MathJaxReact from 'react-mathjax'
+import { useSelector } from 'react-redux'
 import { TocAst } from '../../../external-types/markdown-it-toc-done-right/interface'
+import { ApplicationState } from '../../../redux'
 import { slugify } from '../../../utils/slugify'
 import { InternalLink } from '../../common/links/internal-link'
 import { ShowIf } from '../../common/show-if/show-if'
@@ -93,6 +95,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       oldFirstHeadingRef.current = firstHeadingRef.current
     }
   })
+  const plantumlServer: string | null = useSelector((state: ApplicationState) => state.backendConfig.plantumlServer)
 
   const markdownIt = useMemo(() => {
     const md = new MarkdownIt('default', {
@@ -128,11 +131,13 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
       })
     }
     md.use(taskList)
-    md.use(plantuml, {
-      openMarker: '```plantuml',
-      closeMarker: '```',
-      server: 'http://www.plantuml.com/plantuml'
-    })
+    if (plantumlServer) {
+      md.use(plantuml, {
+        openMarker: '```plantuml',
+        closeMarker: '```',
+        server: plantumlServer
+      })
+    }
     md.use(emoji)
     md.use(abbreviation)
     md.use(definitionList)
@@ -201,7 +206,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onM
     })
 
     return md
-  }, [onMetaDataChange, onFirstHeadingChange])
+  }, [onMetaDataChange, onFirstHeadingChange, plantumlServer])
 
   useEffect(() => {
     if (onTocChange && tocAst && !equal(tocAst, lastTocAst)) {

--- a/src/external-types/markdown-it-plantuml/index.d.ts
+++ b/src/external-types/markdown-it-plantuml/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'markdown-it-plantuml' {
   import MarkdownIt from 'markdown-it/lib'
-  const markdownItPlantuml: MarkdownIt.PluginWithOptions
+  import { PlantumlOptions } from './interface'
+  const markdownItPlantuml: MarkdownIt.PluginWithOptions<PlantumlOptions>
   export = markdownItPlantuml
 }

--- a/src/external-types/markdown-it-plantuml/index.d.ts
+++ b/src/external-types/markdown-it-plantuml/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'markdown-it-plantuml' {
+  import MarkdownIt from 'markdown-it/lib'
+  const markdownItPlantuml: MarkdownIt.PluginWithOptions
+  export = markdownItPlantuml
+}

--- a/src/external-types/markdown-it-plantuml/interface.d.ts
+++ b/src/external-types/markdown-it-plantuml/interface.d.ts
@@ -1,0 +1,8 @@
+import Renderer from 'markdown-it/lib/renderer'
+
+export interface PlantumlOptions {
+  openMarker: string
+  closeMarker: string
+  render: Renderer
+  generateSource: (umlCode: string, pluginOptions: PlantumlOptions) => string
+}

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -31,6 +31,7 @@ export const initialState: Config = {
     saml: ''
   },
   useImageProxy: false,
+  plantumlServer: null,
   specialLinks: {
     privacy: '',
     termsOfUse: '',

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -31,10 +31,7 @@ export const initialState: Config = {
     saml: ''
   },
   useImageProxy: false,
-  plantuml: {
-    enable: false,
-    server: null
-  },
+  plantumlServer: null,
   specialLinks: {
     privacy: '',
     termsOfUse: '',

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -31,7 +31,10 @@ export const initialState: Config = {
     saml: ''
   },
   useImageProxy: false,
-  plantumlServer: null,
+  plantuml: {
+    enable: false,
+    server: null
+  },
   specialLinks: {
     privacy: '',
     termsOfUse: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8096,6 +8096,11 @@ markdown-it-mathjax@2.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz#ae2b4f4c5c719a03f9e475c664f7b2685231d9e9"
   integrity sha1-ritPTFxxmgP55HXGZPeyaFIx2ek=
 
+markdown-it-plantuml@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-plantuml/-/markdown-it-plantuml-1.4.1.tgz#3bd5e7d92eaa5c6c68eb29802f7b46a8e05ca998"
+  integrity sha512-13KgnZaGYTHBp4iUmGofzZSBz+Zj6cyqfR0SXUIc9wgWTto5Xhn7NjaXYxY0z7uBeTUMlc9LMQq5uP4OM5xCHg==
+
 markdown-it-regex@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/markdown-it-regex/-/markdown-it-regex-0.2.0.tgz#e09ad2d75209720d591d3949e1142c75c0fbecf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8096,7 +8096,7 @@ markdown-it-mathjax@2.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz#ae2b4f4c5c719a03f9e475c664f7b2685231d9e9"
   integrity sha1-ritPTFxxmgP55HXGZPeyaFIx2ek=
 
-markdown-it-plantuml@^1.4.1:
+markdown-it-plantuml@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/markdown-it-plantuml/-/markdown-it-plantuml-1.4.1.tgz#3bd5e7d92eaa5c6c68eb29802f7b46a8e05ca998"
   integrity sha512-13KgnZaGYTHBp4iUmGofzZSBz+Zj6cyqfR0SXUIc9wgWTto5Xhn7NjaXYxY0z7uBeTUMlc9LMQq5uP4OM5xCHg==


### PR DESCRIPTION
### Component/Part
Add PlantUML rendering support.

### Description
Code block like

    ```plantuml
    Bob -> Alice : hello
    ```
are rendered as PlantUML diagrams using a PlantUML server.

![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80)

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
<!-- e.g #123 -->
#324 