### PR TITLE
Correct browser name in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        browser: ['e2e:chrome', 'e2e:firefox']
+        browser: ['chrome', 'firefox']
     name: ${{ matrix.browser }}
     steps:
       - name: Checkout repository
@@ -30,5 +30,5 @@ jobs:
         run: sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Install dependencies
         run: yarn install
-      - name: Run e2e in chrome
-        run: yarn ${{ matrix.browser }}
+      - name: Run e2e in ${{ matrix.browser }}
+        run: yarn e2e:${{ matrix.browser }}


### PR DESCRIPTION
### Component/Part
GitHub Workflow for e2e tests

### Description
This PR changes the e2e task name. so that it uses the browser name instead of always "chrome"
