### PR TITLE
Fix firefox e2e runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cypress-io/github-action@v2
+        env:
+          MOZ_FORCE_DISABLE_E10S: 1
         with:
           browser: ${{ matrix.browser }}
           start: npm start

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cypress-io/github-action@v2
-        env:
-          MOZ_FORCE_DISABLE_E10S: 1
         with:
           browser: ${{ matrix.browser }}
           start: npm start

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3000/",
+  "defaultCommandTimeout": 10000,
   "experimentalFetchPolyfill": true,
   "firefoxGcInterval": {
     "runMode": null,

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:3000/",
-  "defaultCommandTimeout": 10000,
+  "defaultCommandTimeout": 15000,
   "experimentalFetchPolyfill": true,
   "firefoxGcInterval": {
     "runMode": null,

--- a/cypress.json
+++ b/cypress.json
@@ -1,9 +1,5 @@
 {
   "baseUrl": "http://localhost:3000/",
   "defaultCommandTimeout": 15000,
-  "experimentalFetchPolyfill": true,
-  "firefoxGcInterval": {
-    "runMode": null,
-    "openMode": null
-  }
+  "experimentalFetchPolyfill": true
 }


### PR DESCRIPTION
### Component/Part
<!-- e.g markdown editor -->
E2E tests in headless firefox

### Description
This PR fixes the unstable behaviour of the firefox e2e execution by increasing the time to wait for results when executing a cypress command.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

### Related Issue(s)
Closes #356 
