### PR TITLE
Add automerge config to renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,18 @@
   ],
   "packageRules": [
     {
+      "updateTypes": ["pin"],
+      "automerge": true
+    },
+    {
       "extends": "packages:linters",
-      "groupName": "linters"
+      "groupName": "linters",
+      "automerge": true
     },
     {
       "extends": "monorepo:typescript-eslint",
-      "groupName": "typescript-eslint monorepo"
+      "groupName": "typescript-eslint monorepo",
+      "automerge": true
     },
     {
       "extends": "monorepo:react",
@@ -26,13 +32,15 @@
       "groupName": "definitelyTyped",
       "packagePatterns": [
         "^@types/"
-      ]
+      ],
+      "automerge": true
     },
     {
       "groupName": "JS test packages",
       "packagePatterns": [
         "^@testing-library/"
-      ]
+      ],
+      "automerge": true
     }
   ],
   "prHourlyLimit": 0,


### PR DESCRIPTION
### Component/Part
renovatebot configuration

### Description
This patch adds the ability to automatically merge PRs from renovate
bot for certain update types, such as package pinning or linter, types
and test-library packages.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog