### PR TITLE
Allow word break in renderer

### DIFF
--- a/src/components/editor/markdown-renderer/markdown-renderer.scss
+++ b/src/components/editor/markdown-renderer/markdown-renderer.scss
@@ -3,6 +3,7 @@
 .markdown-body {
   position: relative;
   font-family: 'Source Sans Pro', "twemoji", sans-serif;
+  word-break: break-word;
 
   .alert > p, .alert > ul {
     margin-bottom: 0;


### PR DESCRIPTION
### Component/Part
Markdown renderer

### Description
If you write a very long line in the editor, that can't be wrapped, because it's one word, then the renderer's width will grow too much.
This PR allow breaking of words in the renderer.

### Steps

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog
