### PR TITLE
Insert short code instead of native emoji

### DIFF
--- a/src/components/editor/editor-window/tool-bar/utils.test.ts
+++ b/src/components/editor/editor-window/tool-bar/utils.test.ts
@@ -1661,7 +1661,7 @@ describe('test addEmoji with native emoji', () => {
       ),
       getLine: (): string => (textFirstLine),
       replaceRange: (replacement: string | string[]) => {
-        expect(replacement).toEqual('👍')
+        expect(replacement).toEqual(':+1:')
         done()
       }
     })
@@ -1683,7 +1683,7 @@ describe('test addEmoji with native emoji', () => {
       replaceRange: (replacement: string | string[], from: CodeMirror.Position, to?: CodeMirror.Position) => {
         expect(from).toEqual(firstLine.from)
         expect(to).toEqual(firstLine.to)
-        expect(replacement).toEqual('👍')
+        expect(replacement).toEqual(':+1:')
         done()
       }
     })
@@ -1705,7 +1705,7 @@ describe('test addEmoji with native emoji', () => {
       replaceRange: (replacement: string | string[], from: CodeMirror.Position, to?: CodeMirror.Position) => {
         expect(from).toEqual(multiline.from)
         expect(to).toEqual(multiline.to)
-        expect(replacement).toEqual('👍')
+        expect(replacement).toEqual(':+1:')
         done()
       }
     })
@@ -1727,7 +1727,7 @@ describe('test addEmoji with native emoji', () => {
       replaceRange: (replacement: string | string[], from: CodeMirror.Position, to?: CodeMirror.Position) => {
         expect(from).toEqual(multilineOffset.from)
         expect(to).toEqual(multilineOffset.to)
-        expect(replacement).toEqual('👍')
+        expect(replacement).toEqual(':+1:')
         done()
       }
     })

--- a/src/components/editor/editor-window/tool-bar/utils.test.ts
+++ b/src/components/editor/editor-window/tool-bar/utils.test.ts
@@ -1646,7 +1646,7 @@ describe('test addEmoji with native emoji', () => {
   const { cursor, firstLine, multiline, multilineOffset } = buildRanges()
   const textFirstLine = testContent.split('\n')[0]
   const emoji = Mock.of<EmojiData>({
-    native: '👍'
+    colons: ':+1:'
   })
   it('just cursor', done => {
     Mock.extend(editor).with({

--- a/src/components/editor/editor-window/tool-bar/utils.ts
+++ b/src/components/editor/editor-window/tool-bar/utils.ts
@@ -25,7 +25,7 @@ export const addTable = (editor: Editor): void => changeLines(editor, line => `$
 
 export const addEmoji = (emoji: EmojiData, editor: Editor): void => {
   let replacement = ''
-  if ((emoji as BaseEmoji).native) {
+  if ((emoji as BaseEmoji).colons) {
     replacement = (emoji as BaseEmoji).colons
   } else if ((emoji as CustomEmoji).imageUrl) {
     // noinspection CheckTagEmptyBody

--- a/src/components/editor/editor-window/tool-bar/utils.ts
+++ b/src/components/editor/editor-window/tool-bar/utils.ts
@@ -26,7 +26,7 @@ export const addTable = (editor: Editor): void => changeLines(editor, line => `$
 export const addEmoji = (emoji: EmojiData, editor: Editor): void => {
   let replacement = ''
   if ((emoji as BaseEmoji).native) {
-    replacement = (emoji as BaseEmoji).native
+    replacement = (emoji as BaseEmoji).colons
   } else if ((emoji as CustomEmoji).imageUrl) {
     // noinspection CheckTagEmptyBody
     replacement = `<i class="fa ${(emoji as CustomEmoji).name}"></i>`


### PR DESCRIPTION
### Component/Part
The emoji picker

### Description
This PR changes the emoji picker behaviour. It should insert the short code (`:+1:`) instead of the unicode symbol (:+1:)

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [x] added / updated documentation
- [x] extended changelog

