### PR TITLE
pdf export unavailability notice

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -246,9 +246,7 @@
             "keymap": "Keymap",
             "tabCharacter": "Tab character",
             "tabSize": "Tab size",
-            "spellChecker": "Spell checking",
-            "pdf": "PDF export is unavailable.",
-            "why": "Why?"
+            "spellChecker": "Spell checking"
         },
         "statusBar": {
             "cursor": "Line {{line}}, Columns {{columns}}",
@@ -261,7 +259,9 @@
             "lengthTooltip": "You can write up to 100000 characters in this document."
         },
         "export": {
-            "rawHtml": "Raw HTML"
+            "rawHtml": "Raw HTML",
+            "pdf": "PDF export is unavailable.",
+            "why": "Why?"
         },
         "import": {
             "clipboard": "Clipboard"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -246,7 +246,9 @@
             "keymap": "Keymap",
             "tabCharacter": "Tab character",
             "tabSize": "Tab size",
-            "spellChecker": "Spell checking"
+            "spellChecker": "Spell checking",
+            "pdf": "PDF Export is unavailable.",
+            "why": "Why?"
         },
         "statusBar": {
             "cursor": "Line {{line}}, Columns {{columns}}",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -247,7 +247,7 @@
             "tabCharacter": "Tab character",
             "tabSize": "Tab size",
             "spellChecker": "Spell checking",
-            "pdf": "PDF Export is unavailable.",
+            "pdf": "PDF export is unavailable.",
             "why": "Why?"
         },
         "statusBar": {

--- a/src/components/editor/document-bar/export-menu.tsx
+++ b/src/components/editor/document-bar/export-menu.tsx
@@ -49,7 +49,7 @@ const ExportMenu: React.FC = () => {
           <ForkAwesomeIcon icon='file-pdf-o' className={'mx-2'}/>
           <Trans i18nKey={'editor.menu.pdf'}/>
           &nbsp;
-          <TranslatedExternalLink i18nKey={'editor.menu.why'} href={'https://github.com/codimd/server/wiki/FAQ#why-was-the-pdf-export-feature-removed'} className={'text-primary'}/>
+          <TranslatedExternalLink i18nKey={'editor.menu.why'} href={'https://community.codimd.org/t/frequently-asked-questions/190'} className={'text-primary'}/>
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>

--- a/src/components/editor/document-bar/export-menu.tsx
+++ b/src/components/editor/document-bar/export-menu.tsx
@@ -47,9 +47,9 @@ const ExportMenu: React.FC = () => {
 
         <Dropdown.Item className='small text-muted' dir={'auto'}>
           <ForkAwesomeIcon icon='file-pdf-o' className={'mx-2'}/>
-          <Trans i18nKey={'editor.menu.pdf'}/>
+          <Trans i18nKey={'editor.export.pdf'}/>
           &nbsp;
-          <TranslatedExternalLink i18nKey={'editor.menu.why'} href={'https://community.codimd.org/t/frequently-asked-questions/190'} className={'text-primary'}/>
+          <TranslatedExternalLink i18nKey={'editor.export.why'} href={'https://community.codimd.org/t/frequently-asked-questions/190'} className={'text-primary'}/>
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>

--- a/src/components/editor/document-bar/export-menu.tsx
+++ b/src/components/editor/document-bar/export-menu.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { ForkAwesomeIcon } from '../../common/fork-awesome/fork-awesome-icon'
+import { TranslatedExternalLink } from '../../common/links/translated-external-link'
 
 const ExportMenu: React.FC = () => {
   useTranslation()
@@ -40,6 +41,15 @@ const ExportMenu: React.FC = () => {
         <Dropdown.Item className='small'>
           <ForkAwesomeIcon icon='file-code-o' className={'mx-2'}/>
           <Trans i18nKey='editor.export.rawHtml'/>
+        </Dropdown.Item>
+
+        <Dropdown.Divider/>
+
+        <Dropdown.Item className='small text-muted' dir={'auto'}>
+          <ForkAwesomeIcon icon='file-pdf-o' className={'mx-2'}/>
+          <Trans i18nKey={'editor.menu.pdf'}/>
+          &nbsp;
+          <TranslatedExternalLink i18nKey={'editor.menu.why'} href={'https://github.com/codimd/server/wiki/FAQ#why-was-the-pdf-export-feature-removed'} className={'text-primary'}/>
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>


### PR DESCRIPTION
### Component/Part
the editor menu

### Description
This PR added pdf export unavailability notice with link to FAQ.
As many users ask all the time why this was removed and when they'll get it back, this seemed like a fine solution in the meantime.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
#401

### Additional Information
![image](https://user-images.githubusercontent.com/3978662/89941480-5e260880-dc1b-11ea-9069-f77ca69eb94e.png)
