### PR TITLE
Use prod build for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,28 @@ on:
     branches: [main]
 
 jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    name: build frontend
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache node_modules
+        uses: actions/cache@v1.1.0
+        with:
+          path: node_modules
+          key: node_modules
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: yarn install
+      - run: yarn build
+      - uses: actions/upload-artifact@master
+        with:
+          name: build
+          path: build
+
   end2end:
+    needs: build-frontend
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,7 +36,11 @@ jobs:
     name: e2e:${{ matrix.browser }}
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/download-artifact@master
+        with:
+          name: build
+          path: build
       - uses: cypress-io/github-action@v2
         with:
           browser: ${{ matrix.browser }}
-          start: npm start
+          start: 'yarn build:serve'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,11 @@ jobs:
     name: build frontend
     steps:
       - uses: actions/checkout@v1
+      - name: Cache build
+        uses: actions/cache@v1.1.0
+        with:
+          path: build
+          key: build
       - name: Cache node_modules
         uses: actions/cache@v1.1.0
         with:

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:3001/",
+  "baseUrl": "http://127.0.0.1:3001/",
   "defaultCommandTimeout": 15000,
   "experimentalFetchPolyfill": true
 }

--- a/package.json
+++ b/package.json
@@ -92,61 +92,61 @@
     "scripts": {
         "start": "PORT=3001 react-scripts start",
         "start:dev": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
-        "build:serve": "http-server build/ -p 3001 -P \"http://127.0.0.1:3001?\"",
-    "build": "react-scripts build",
+        "build:serve": "http-server build/ -s -p 3001 -P \"http://127.0.0.1:3001?\"",
+        "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "cy:open": "cypress open",
         "cy:run:chrome": "cypress run --browser chrome",
         "cy:run:firefox": "cypress run --browser firefox"
-  },
-  "eslintConfig": {
-    "parserOptions": {
-      "tsconfigRootDir": "",
-      "project": [
-        "./tsconfig.json"
-      ]
     },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "react-app",
-      "standard",
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking",
-      "plugin:import/recommended",
-      "plugin:import/typescript"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "devDependencies": {
-    "@cypress/webpack-preprocessor": "5.4.4",
-    "@testing-library/cypress": "6.0.0",
-    "@types/redux-devtools": "3.0.47",
-    "@types/redux-devtools-extension": "2.13.2",
-    "@types/testing-library__cypress": "5.0.6",
-    "cypress": "4.12.1",
-    "eslint-plugin-chai-friendly": "0.6.0",
-    "eslint-plugin-cypress": "2.11.1",
-    "redux-devtools": "3.6.1",
-    "redux-devtools-extension": "2.13.8",
-    "ts-loader": "8.0.2",
-    "http-server": "0.12.3"
-  },
+    "eslintConfig": {
+        "parserOptions": {
+            "tsconfigRootDir": "",
+            "project": [
+                "./tsconfig.json"
+            ]
+        },
+        "plugins": [
+            "@typescript-eslint"
+        ],
+        "extends": [
+            "react-app",
+            "standard",
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended",
+            "plugin:@typescript-eslint/recommended-requiring-type-checking",
+            "plugin:import/recommended",
+            "plugin:import/typescript"
+        ]
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    },
+    "devDependencies": {
+        "@cypress/webpack-preprocessor": "5.4.4",
+        "@testing-library/cypress": "6.0.0",
+        "@types/redux-devtools": "3.0.47",
+        "@types/redux-devtools-extension": "2.13.2",
+        "@types/testing-library__cypress": "5.0.6",
+        "cypress": "4.12.1",
+        "eslint-plugin-chai-friendly": "0.6.0",
+        "eslint-plugin-cypress": "2.11.1",
+        "redux-devtools": "3.6.1",
+        "redux-devtools-extension": "2.13.8",
+        "ts-loader": "8.0.2",
+        "http-server": "0.12.3"
+    },
     "resolutions": {
         "cypress": "4.12.1"
     }

--- a/package.json
+++ b/package.json
@@ -92,61 +92,61 @@
     "scripts": {
         "start": "PORT=3001 react-scripts start",
         "start:dev": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
-        "build": "react-scripts build",
+        "build:serve": "http-server build/ -p 3001 -P \"http://127.0.0.1:3001?\"",
+    "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "cy:open": "cypress open",
         "cy:run:chrome": "cypress run --browser chrome",
-        "cy:run:firefox": "cypress run --browser firefox",
-        "e2e:chrome": "start-server-and-test start http-get://localhost:3001 cy:run:chrome",
-        "e2e:firefox": "start-server-and-test start http-get://localhost:3001 cy:run:firefox"
+        "cy:run:firefox": "cypress run --browser firefox"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "tsconfigRootDir": "",
+      "project": [
+        "./tsconfig.json"
+      ]
     },
-    "eslintConfig": {
-        "parserOptions": {
-            "tsconfigRootDir": "",
-            "project": [
-                "./tsconfig.json"
-            ]
-        },
-        "plugins": [
-            "@typescript-eslint"
-        ],
-        "extends": [
-            "react-app",
-            "standard",
-            "eslint:recommended",
-            "plugin:@typescript-eslint/eslint-recommended",
-            "plugin:@typescript-eslint/recommended",
-            "plugin:@typescript-eslint/recommended-requiring-type-checking",
-            "plugin:import/recommended",
-            "plugin:import/typescript"
-        ]
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
-    "devDependencies": {
-        "@cypress/webpack-preprocessor": "5.4.4",
-        "@testing-library/cypress": "6.0.0",
-        "@types/redux-devtools": "3.0.47",
-        "@types/redux-devtools-extension": "2.13.2",
-        "@types/testing-library__cypress": "5.0.6",
-        "cypress": "4.12.1",
-        "eslint-plugin-chai-friendly": "0.6.0",
-        "eslint-plugin-cypress": "2.11.1",
-        "redux-devtools": "3.6.1",
-        "redux-devtools-extension": "2.13.8",
-        "ts-loader": "8.0.2"
-    },
+    "plugins": [
+      "@typescript-eslint"
+    ],
+    "extends": [
+      "react-app",
+      "standard",
+      "eslint:recommended",
+      "plugin:@typescript-eslint/eslint-recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      "plugin:import/recommended",
+      "plugin:import/typescript"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@cypress/webpack-preprocessor": "5.4.4",
+    "@testing-library/cypress": "6.0.0",
+    "@types/redux-devtools": "3.0.47",
+    "@types/redux-devtools-extension": "2.13.2",
+    "@types/testing-library__cypress": "5.0.6",
+    "cypress": "4.12.1",
+    "eslint-plugin-chai-friendly": "0.6.0",
+    "eslint-plugin-cypress": "2.11.1",
+    "redux-devtools": "3.6.1",
+    "redux-devtools-extension": "2.13.8",
+    "ts-loader": "8.0.2",
+    "http-server": "0.12.3"
+  },
     "resolutions": {
         "cypress": "4.12.1"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,6 +2893,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
+  integrity sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -3621,7 +3626,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -3820,6 +3825,11 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+corser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
+  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
 
 cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
   version "5.2.1"
@@ -4616,6 +4626,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecstatic@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
+  integrity sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==
+  dependencies:
+    he "^1.1.1"
+    mime "^1.6.0"
+    minimist "^1.1.0"
+    url-join "^2.0.5"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6040,7 +6060,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@^1.2.0:
+he@^1.1.1, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -6226,7 +6246,7 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy@^1.17.0, http-proxy@^1.18.0:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -6234,6 +6254,22 @@ http-proxy@^1.17.0:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-server@0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.12.3.tgz#ba0471d0ecc425886616cb35c4faf279140a0d37"
+  integrity sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==
+  dependencies:
+    basic-auth "^1.0.3"
+    colors "^1.4.0"
+    corser "^2.0.1"
+    ecstatic "^3.3.2"
+    http-proxy "^1.18.0"
+    minimist "^1.2.5"
+    opener "^1.5.1"
+    portfinder "^1.0.25"
+    secure-compare "3.0.1"
+    union "~0.5.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -8238,7 +8274,7 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.44.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -8298,7 +8334,7 @@ minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -8842,6 +8878,11 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -9282,7 +9323,7 @@ popper.js@^1.14.4, popper.js@^1.15.0:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
-portfinder@^1.0.26:
+portfinder@^1.0.25, portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
   integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
@@ -10136,6 +10177,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+qs@^6.4.0:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -11165,6 +11211,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+secure-compare@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -12379,6 +12430,13 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
+union@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
+  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
+  dependencies:
+    qs "^6.4.0"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -12447,6 +12505,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
+  integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
 
 url-loader@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
### Component/Part
The e2e tests

### Description
This PR changes the e2e workflow. It now uses the prod build, because that is what we actually want to test. It could also fix the firefox timeout.

### Steps

- [x] added implementation
- [x] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog
