### PR TITLE
Disable videos in cypress CI config

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3001/",
   "defaultCommandTimeout": 15000,
-  "experimentalFetchPolyfill": true
+  "experimentalFetchPolyfill": true,
+  "video": false
 }


### PR DESCRIPTION
### Component/Part
CI -> end to end tests (cypress)

### Description
While running tests, cypress records videos of each one and processes them afterwards. This needs some resources we could save to reduce the CI runtime as we don't use or upload these videos.
This PR disables the video recording of cypress.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation -> _(not applicable)_
- [x] added / updated tests
- [x] added / updated documentation -> _(not applicable)_
- [x] extended changelog -> _(not applicable)_

### Related Issue(s)
none
