### PR TITLE
Fix editor being filled with €-symbols when pressing the editor-mode-shortcut on certain platforms

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -66,9 +66,9 @@ export const Editor: React.FC = () => {
   }, [updateDocumentTitle])
 
   useEffect(() => {
-    document.addEventListener('keyup', shortcutHandler, false)
+    document.addEventListener('keydown', shortcutHandler, false)
     return () => {
-      document.removeEventListener('keyup', shortcutHandler, false)
+      document.removeEventListener('keydown', shortcutHandler, false)
     }
   }, [])
 

--- a/src/components/editor/shortcut/shortcut.ts
+++ b/src/components/editor/shortcut/shortcut.ts
@@ -4,13 +4,16 @@ import { EditorMode } from '../app-bar/editor-view-mode'
 export const shortcutHandler = (event: KeyboardEvent): void => {
   if (event.ctrlKey && event.altKey && event.key === 'b') {
     setEditorMode(EditorMode.BOTH)
+    event.preventDefault()
   }
 
   if (event.ctrlKey && event.altKey && event.key === 'v') {
     setEditorMode(EditorMode.PREVIEW)
+    event.preventDefault()
   }
 
-  if (event.ctrlKey && event.altKey && event.key === 'e') {
+  if (event.ctrlKey && event.altKey && (event.key === 'e' || event.key === '€')) {
     setEditorMode(EditorMode.EDITOR)
+    event.preventDefault()
   }
 }


### PR DESCRIPTION
### Component/Part
Editor -> Shortcuts

### Description
This fix needs a little bit of explanation. Normally the 'keyUp' prevent is preferred because it fires after being sure, that not some buttons more belong to the shortcut. Additionally, some platforms set the key-property of the 'keyDown'-event to the composition result of the key-combination thus resolving under certain environments to '€' while in other environments to 'e'.
The browser's event flow is as following: keyDown -> keyPress -> textInput -> keyUp.
As the keyUp-event is too late (after textinput) and the keyPress-event does not work properly with the modifiers, we felt compelled to use 'keyDown' and watch for 'e' as well as '€' key-properties. If some other keyboard locale does output different characters than these two, that person got a problem - meaning no functionality of the shortcut. But still better than nothing.


### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
none
