### PR TITLE
Remove @types/react-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "@types/node": "12.12.53",
         "@types/node-sass": "4.11.1",
         "@types/react": "16.9.48",
-        "@types/react-bootstrap": "1.0.1",
         "@types/react-bootstrap-typeahead": "3.4.6",
         "@types/react-dom": "16.9.8",
         "@types/react-html-parser": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,11 +1886,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-bootstrap@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-bootstrap/-/react-bootstrap-1.0.1.tgz#3badd512fc37913b5e72f1ed94e3aacbd1452d97"
-  integrity sha512-n68SeFrpOFWiSN2DCpyn17ZwTZzY8+mio8E9oCrl7abHytUz3r7ZYIKPxaETHYQxCi8oxF3NultpMAyBxFIjhg==
-
 "@types/react-dom@16.9.8":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"


### PR DESCRIPTION
This PR removes @types/react-bootstrap, because react-bootstrap ships it's own types now.