### PR TITLE
check that the title attribute is set for images

### DIFF
--- a/cypress/integration/autocompletion.spec.ts
+++ b/cypress/integration/autocompletion.spec.ts
@@ -183,6 +183,7 @@ describe('Autocompletion', () => {
       cy.get('.markdown-body > p > img')
         .should('have.attr', 'alt', 'image alt')
         .should('have.attr', 'src', 'https://')
+        .should('have.attr', 'title', 'title')
     })
     it('via doubleclick', () => {
       cy.get('.CodeMirror textarea')
@@ -197,6 +198,7 @@ describe('Autocompletion', () => {
       cy.get('.markdown-body > p > img')
         .should('have.attr', 'alt', 'image alt')
         .should('have.attr', 'src', 'https://')
+        .should('have.attr', 'title', 'title')
     })
   })
 


### PR DESCRIPTION
### Component/Part
auto completion e2e test

### Description
This PR improves the auto completion e2e test by checking if the title attribute is set for images.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [ ] added implementation
- [x] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
fixes #522 
