### PR TITLE
Replace editor toolbar dividers with css pseudo-selector

### DIFF
--- a/src/components/editor/editor-pane/tool-bar/tool-bar.scss
+++ b/src/components/editor/editor-pane/tool-bar/tool-bar.scss
@@ -1,11 +1,11 @@
 .btn-toolbar {
   border: 1px solid #ededed;
-}
 
-.btn-toolbar .btn-group:not(:last-of-type)::after {
-  background-color: #e2e6ea;
-  width: 2px;
-  padding: 0.25rem 0;
-  content: ' ';
-  margin-left: 0.5rem;
+  .btn-group:not(:last-of-type)::after {
+    background-color: #e2e6ea;
+    width: 2px;
+    padding: 0.25rem 0;
+    content: ' ';
+    margin-left: 0.5rem;
+  }
 }

--- a/src/components/editor/editor-pane/tool-bar/tool-bar.scss
+++ b/src/components/editor/editor-pane/tool-bar/tool-bar.scss
@@ -2,8 +2,10 @@
   border: 1px solid #ededed;
 }
 
-.divider {
+.btn-toolbar .btn-group:not(:last-of-type)::after {
   background-color: #e2e6ea;
   width: 2px;
   padding: 0.25rem 0;
+  content: ' ';
+  margin-left: 0.5rem;
 }

--- a/src/components/editor/editor-pane/tool-bar/tool-bar.tsx
+++ b/src/components/editor/editor-pane/tool-bar/tool-bar.tsx
@@ -65,7 +65,6 @@ export const ToolBar: React.FC<ToolBarProps> = ({ editor, onPreferencesChange, e
           <ForkAwesomeIcon icon="superscript"/>
         </Button>
       </ButtonGroup>
-      <span className={'divider'}>&nbsp;</span>
       <ButtonGroup className={'mx-1 flex-wrap'}>
         <Button variant='light' onClick={() => addHeaderLevel(editor)} title={t('editor.editorToolbar.header')}>
           <ForkAwesomeIcon icon="header"/>
@@ -86,7 +85,6 @@ export const ToolBar: React.FC<ToolBarProps> = ({ editor, onPreferencesChange, e
           <ForkAwesomeIcon icon="check-square"/>
         </Button>
       </ButtonGroup>
-      <span className={'divider'}>&nbsp;</span>
       <ButtonGroup className={'mx-1 flex-wrap'}>
         <Button variant='light' onClick={() => addLink(editor)} title={t('editor.editorToolbar.link')}>
           <ForkAwesomeIcon icon="link"/>
@@ -98,7 +96,6 @@ export const ToolBar: React.FC<ToolBarProps> = ({ editor, onPreferencesChange, e
           <ForkAwesomeIcon icon="upload"/>
         </Button>
       </ButtonGroup>
-      <span className={'divider'}>&nbsp;</span>
       <ButtonGroup className={'mx-1 flex-wrap'}>
         <Button variant='light' onClick={() => addTable(editor)} title={t('editor.editorToolbar.table')}>
           <ForkAwesomeIcon icon="table"/>
@@ -111,7 +108,6 @@ export const ToolBar: React.FC<ToolBarProps> = ({ editor, onPreferencesChange, e
         </Button>
         <EmojiPickerButton editor={editor}/>
       </ButtonGroup>
-      <span className={'divider'}>&nbsp;</span>
       <ButtonGroup className={'mx-1 flex-wrap'}>
         <EditorPreferences onPreferencesChange={onPreferencesChange} preferences={editorPreferences}/>
       </ButtonGroup>


### PR DESCRIPTION
### Component/Part
Editor -> Toolbar

### Description
The use of extra divider elements is not needed as we can set the css-after pseudo-class to the button groups with the same styling.
This way we can reduce the amount of elements in the DOM by a hand full.

### Steps
<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests _(not necessary)_
- [ ] added / updated documentation _(not necessary)_
- [ ] extended changelog _(not necessary)_

### Related Issue(s)
none
