### PR TITLE
Replace history-menu icon from bars to vertical dots

### DIFF
--- a/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/src/components/history-page/entry-menu/entry-menu.tsx
@@ -24,7 +24,7 @@ const EntryMenu: React.FC<EntryMenuProps> = ({ id, title, location, isDark, onRe
   return (
     <Dropdown className={`d-inline-flex ${className || ''}`}>
       <Dropdown.Toggle variant={isDark ? 'secondary' : 'light'} id={`dropdown-card-${id}`} className='no-arrow history-menu d-inline-flex align-items-center'>
-        <ForkAwesomeIcon icon="bars" className=''/>
+        <ForkAwesomeIcon icon="ellipsis-h"/>
       </Dropdown.Toggle>
 
       <Dropdown.Menu>

--- a/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/src/components/history-page/entry-menu/entry-menu.tsx
@@ -24,7 +24,7 @@ const EntryMenu: React.FC<EntryMenuProps> = ({ id, title, location, isDark, onRe
   return (
     <Dropdown className={`d-inline-flex ${className || ''}`}>
       <Dropdown.Toggle variant={isDark ? 'secondary' : 'light'} id={`dropdown-card-${id}`} className='no-arrow history-menu d-inline-flex align-items-center'>
-        <ForkAwesomeIcon icon="ellipsis-h"/>
+        <ForkAwesomeIcon icon="ellipsis-v" fixedWidth={true}/>
       </Dropdown.Toggle>
 
       <Dropdown.Menu>


### PR DESCRIPTION
### Component/Part
History page -> Menu button on history entries (table or cards)

### Description
This PR changes the icon for the menu of history-entries from bars to vertical dots as discussed in #492.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests _(no tests to change)_
- [ ] added / updated documentation _(no documentation for this menu existing yet)_
- [ ] extended changelog _(not applicable)_

### Related Issue(s)
fixes #492 
