### PR TITLE
Add markdown body to cheatsheet

### DIFF
--- a/src/components/editor/app-bar/help-button/cheatsheet.tsx
+++ b/src/components/editor/app-bar/help-button/cheatsheet.tsx
@@ -50,7 +50,7 @@ export const Cheatsheet: React.FC = () => {
                   onLineMarkerPositionChanged={() => false}
                 />
               </td>
-              <td>
+              <td className={'markdown-body'}>
                 <HighlightedCode code={code} wrapLines={true} startLineNumber={1} language={'markdown'}/>
               </td>
             </tr>


### PR DESCRIPTION
This PR fixes the code highlightning in the cheatsheet modal.