### PR TITLE
Show warning if note is longer than configured maximum length

### DIFF
--- a/cypress/integration/maxLength.spec.ts
+++ b/cypress/integration/maxLength.spec.ts
@@ -1,0 +1,49 @@
+const tenChars: string = '0123456789'
+
+describe('status-bar text-length info', () => {
+  beforeEach(() => {
+    cy.visit('/n/test')
+    cy.get('.CodeMirror textarea')
+      .type('{ctrl}a', { force: true })
+      .type('{backspace}')
+  })
+
+  it('tooltip shows full remaining on empty text', () => {
+    cy.get('.status-bar div:nth-child(2) span:nth-child(2)')
+      .attribute('title')
+      .should('contain', ' 200 ')
+  })
+
+  it('color is warning on <= 100 chars remaining', () => {
+    cy.get('.CodeMirror textarea')
+    .type(`${tenChars.repeat(10)}`)
+    cy.get('.status-bar div:nth-child(2) span:nth-child(2)')
+      .should('have.class', 'text-warning')
+  })
+
+  it('color is danger on <= 0 chars remaining', () => {
+    cy.get('.CodeMirror textarea')
+    .type(`${tenChars.repeat(20)}`)
+    cy.get('.status-bar div:nth-child(2) span:nth-child(2)')
+    .should('have.class', 'text-danger')
+  })
+})
+
+describe('show warning if content length > configured max length', () => {
+  beforeEach(() => {
+    cy.visit('/n/test')
+    cy.get('.CodeMirror textarea')
+    .type('{ctrl}a', { force: true })
+    .type('{backspace}')
+    .type(`${tenChars.repeat(20)}`)
+  })
+
+  it('show warning alert in renderer and as modal', () => {
+    cy.get('.CodeMirror textarea')
+      .type('a')
+    cy.get('.modal-body.limit-warning')
+      .should('be.visible')
+    cy.get('.splitter .alert-danger')
+    .should('be.visible')
+  })
+})

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
         oauth2: 'Olaf2',
         saml: 'aufSAMLn.de'
       },
+      maxDocumentLength: 200,
       specialLinks: {
         privacy: 'https://example.com/privacy',
         termsOfUse: 'https://example.com/termsOfUse',

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -13,6 +13,7 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+import 'cypress-commands'
 import './checkLinks'
 import './config'
 import './login'

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": "../node_modules",
-    "target": "es5",
-    "lib": ["es5", "dom"],
-    "types": ["cypress"]
+    "target": "es6",
+    "lib": ["es6", "dom"],
+    "types": ["cypress-commands", "cypress"]
   },
   "include": [
     "**/*.ts"

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "@types/redux-devtools": "3.0.47",
         "@types/redux-devtools-extension": "2.13.2",
         "cypress": "5.1.0",
+        "cypress-commands": "^1.1.0",
         "eslint-plugin-chai-friendly": "0.6.0",
         "eslint-plugin-cypress": "2.11.1",
         "http-server": "0.12.3",

--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -27,6 +27,7 @@
     "oauth2": "Olaf2",
     "saml": "aufSAMLn.de"
   },
+  "maxDocumentLength": 100000,
   "useImageProxy": false,
   "plantumlServer": "http://www.plantuml.com/plantuml",
   "specialLinks": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -277,7 +277,7 @@
             },
             "lines": "{{lines}} Lines",
             "length": "Length {{length}}",
-            "lengthTooltip": "You still may write {{remaining}} characters until you reach the limit for this document."
+            "lengthTooltip": "You may still write {{remaining}} characters until you reach the limit for this note."
         },
         "export": {
             "rawHtml": "Raw HTML",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -196,7 +196,7 @@
             },
             "limitReached": {
                 "title": "Reached the limit",
-                "description": "Sorry, you've reached the maximum length this note can be ({{maxLength}} characters).",
+                "description": "Sorry, this note reached its maximum length. Notes can be up to {{maxLength}} characters long.",
                 "advice": "Please shorten the note."
             },
             "incompatible": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -277,7 +277,7 @@
             },
             "lines": "{{lines}} Lines",
             "length": "Length {{length}}",
-            "lengthTooltip": "You can write up to 100000 characters in this document."
+            "lengthTooltip": "You still may write {{remaining}} characters until you reach the limit for this document."
         },
         "export": {
             "rawHtml": "Raw HTML",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -277,7 +277,11 @@
             },
             "lines": "{{lines}} Lines",
             "length": "Length {{length}}",
-            "lengthTooltip": "You may still write {{remaining}} characters until you reach the limit for this note."
+            "lengthTooltip": {
+                "maximumReached": "You've reached the maximum length of this note.",
+                "remaining": "You may still write {{remaining}} characters until you reach the limit for this note.",
+                "exceeded": "You've exceeded the maximum length of this note by {{exceeded}} characters. Consider shortening it."
+            }
         },
         "export": {
             "rawHtml": "Raw HTML",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -195,8 +195,8 @@
                 "description": "Sorry, only the owner can edit this note."
             },
             "limitReached": {
-                "title": "Reach the limit",
-                "description": "Sorry, you've reached the maximum length this note can be.",
+                "title": "Reached the limit",
+                "description": "Sorry, you've reached the maximum length this note can be ({{maxLength}} characters).",
                 "advice": "Please shorten the note."
             },
             "incompatible": {

--- a/src/api/config/types.d.ts
+++ b/src/api/config/types.d.ts
@@ -9,6 +9,7 @@ export interface Config {
   specialLinks: SpecialLinks,
   version: BackendVersion,
   plantumlServer: string | null,
+  maxDocumentLength: number,
 }
 
 export interface BrandingConfig {

--- a/src/components/editor/editor-modals/max-length-warning-modal.tsx
+++ b/src/components/editor/editor-modals/max-length-warning-modal.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Button, Modal } from 'react-bootstrap'
+import { Trans, useTranslation } from 'react-i18next'
+import { CommonModal } from '../../common/modals/common-modal'
+
+export interface MaxLengthWarningModalProps {
+  show: boolean
+  onHide: () => void
+  maxLength: number
+}
+
+export const MaxLengthWarningModal: React.FC<MaxLengthWarningModalProps> = ({ show, onHide, maxLength }) => {
+  useTranslation()
+
+  return (
+    <CommonModal show={show} onHide={onHide} titleI18nKey={'editor.error.limitReached.title'} size={'sm'} closeButton={true}>
+      <Modal.Body>
+        <Trans i18nKey={'editor.error.limitReached.description'} values={{ maxLength }} />
+        <br />
+        <b><Trans i18nKey={'editor.error.limitReached.advice'}/></b>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={onHide}><Trans i18nKey={'common.close'}/></Button>
+      </Modal.Footer>
+    </CommonModal>
+  )
+}

--- a/src/components/editor/editor-modals/max-length-warning-modal.tsx
+++ b/src/components/editor/editor-modals/max-length-warning-modal.tsx
@@ -14,7 +14,7 @@ export const MaxLengthWarningModal: React.FC<MaxLengthWarningModalProps> = ({ sh
 
   return (
     <CommonModal show={show} onHide={onHide} titleI18nKey={'editor.error.limitReached.title'} closeButton={true}>
-      <Modal.Body>
+      <Modal.Body className={'limit-warning'}>
         <Trans i18nKey={'editor.error.limitReached.description'} values={{ maxLength }} />
         <br /><br/>
         <b><Trans i18nKey={'editor.error.limitReached.advice'}/></b>

--- a/src/components/editor/editor-modals/max-length-warning-modal.tsx
+++ b/src/components/editor/editor-modals/max-length-warning-modal.tsx
@@ -16,8 +16,7 @@ export const MaxLengthWarningModal: React.FC<MaxLengthWarningModalProps> = ({ sh
     <CommonModal show={show} onHide={onHide} titleI18nKey={'editor.error.limitReached.title'} closeButton={true}>
       <Modal.Body className={'limit-warning'}>
         <Trans i18nKey={'editor.error.limitReached.description'} values={{ maxLength }} />
-        <br /><br/>
-        <b><Trans i18nKey={'editor.error.limitReached.advice'}/></b>
+        <strong className='mt-2 d-block'><Trans i18nKey={'editor.error.limitReached.advice'}/></strong>
       </Modal.Body>
       <Modal.Footer>
         <Button onClick={onHide}><Trans i18nKey={'common.close'}/></Button>

--- a/src/components/editor/editor-modals/max-length-warning-modal.tsx
+++ b/src/components/editor/editor-modals/max-length-warning-modal.tsx
@@ -13,10 +13,10 @@ export const MaxLengthWarningModal: React.FC<MaxLengthWarningModalProps> = ({ sh
   useTranslation()
 
   return (
-    <CommonModal show={show} onHide={onHide} titleI18nKey={'editor.error.limitReached.title'} size={'sm'} closeButton={true}>
+    <CommonModal show={show} onHide={onHide} titleI18nKey={'editor.error.limitReached.title'} closeButton={true}>
       <Modal.Body>
         <Trans i18nKey={'editor.error.limitReached.description'} values={{ maxLength }} />
-        <br />
+        <br /><br/>
         <b><Trans i18nKey={'editor.error.limitReached.advice'}/></b>
       </Modal.Body>
       <Modal.Footer>

--- a/src/components/editor/editor-pane/editor-pane.tsx
+++ b/src/components/editor/editor-pane/editor-pane.tsx
@@ -25,6 +25,7 @@ import { Controlled as ControlledCodeMirror } from 'react-codemirror2'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { ApplicationState } from '../../../redux'
+import { MaxLengthWarningModal } from '../editor-modals/max-length-warning-modal'
 import { ScrollProps, ScrollState } from '../scroll/scroll-props'
 import { allHinters, findWordAtCursor } from './autocompletion'
 import './editor-pane.scss'
@@ -55,6 +56,7 @@ const onChange = (editor: Editor) => {
 export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentChange, content, scrollState, onScroll, onMakeScrollSource }) => {
   const { t } = useTranslation()
   const maxLength = useSelector((state: ApplicationState) => state.config.maxDocumentLength)
+  const [showMaxLengthWarning, setShowMaxLengthWarning] = useState(false)
   const [editor, setEditor] = useState<Editor>()
   const [statusBarInfo, setStatusBarInfo] = useState<StatusBarInfo>(defaultState)
   const [editorPreferences, setEditorPreferences] = useState<EditorConfiguration>({
@@ -103,9 +105,9 @@ export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentC
 
   const onBeforeChange = useCallback((editor: Editor, data: EditorChange, value: string) => {
     if (value.length > maxLength) {
-      window.alert('too long!')
+      setShowMaxLengthWarning(true)
     }
-    onContentChange(value.substr(0, maxLength))
+    onContentChange(value)
   }, [onContentChange, maxLength])
   const onEditorDidMount = useCallback(mountedEditor => {
     setStatusBarInfo(createStatusInfo(mountedEditor, maxLength))
@@ -148,6 +150,7 @@ export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentC
 
   return (
     <div className={'d-flex flex-column h-100'} onMouseEnter={onMakeScrollSource}>
+      <MaxLengthWarningModal show={showMaxLengthWarning} onHide={() => setShowMaxLengthWarning(false)} maxLength={maxLength}/>
       <ToolBar
         editor={editor}
         onPreferencesChange={config => setEditorPreferences(config)}

--- a/src/components/editor/editor-pane/editor-pane.tsx
+++ b/src/components/editor/editor-pane/editor-pane.tsx
@@ -57,6 +57,7 @@ export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentC
   const { t } = useTranslation()
   const maxLength = useSelector((state: ApplicationState) => state.config.maxDocumentLength)
   const [showMaxLengthWarning, setShowMaxLengthWarning] = useState(false)
+  const maxLengthWarningAlreadyShown = useRef(false)
   const [editor, setEditor] = useState<Editor>()
   const [statusBarInfo, setStatusBarInfo] = useState<StatusBarInfo>(defaultState)
   const [editorPreferences, setEditorPreferences] = useState<EditorConfiguration>({
@@ -104,11 +105,15 @@ export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentC
   }, [editor, scrollState])
 
   const onBeforeChange = useCallback((editor: Editor, data: EditorChange, value: string) => {
-    if (value.length > maxLength) {
+    if (value.length > maxLength && !maxLengthWarningAlreadyShown.current) {
       setShowMaxLengthWarning(true)
+      maxLengthWarningAlreadyShown.current = true
+    }
+    if (value.length <= maxLength) {
+      maxLengthWarningAlreadyShown.current = false
     }
     onContentChange(value)
-  }, [onContentChange, maxLength])
+  }, [onContentChange, maxLength, maxLengthWarningAlreadyShown])
   const onEditorDidMount = useCallback(mountedEditor => {
     setStatusBarInfo(createStatusInfo(mountedEditor, maxLength))
     setEditor(mountedEditor)

--- a/src/components/editor/editor-pane/editor-pane.tsx
+++ b/src/components/editor/editor-pane/editor-pane.tsx
@@ -101,27 +101,21 @@ export const EditorPane: React.FC<EditorPaneProps & ScrollProps> = ({ onContentC
     }
   }, [editor, scrollState])
 
-  const checkDocumentLength = useCallback((length: number) => {
-    if (length > maxLength) {
-      window.alert('max document length reached!')
-      return false
-    }
-    return true
-  }, [maxLength])
-
   const onBeforeChange = useCallback((editor: Editor, data: EditorChange, value: string) => {
-    if (!checkDocumentLength(value.length)) {
-      return
+    if (value.length > maxLength) {
+      window.alert('too long!')
     }
-    onContentChange(value)
-  }, [onContentChange, checkDocumentLength])
+    onContentChange(value.substr(0, maxLength))
+  }, [onContentChange, maxLength])
   const onEditorDidMount = useCallback(mountedEditor => {
     setStatusBarInfo(createStatusInfo(mountedEditor, maxLength))
     setEditor(mountedEditor)
   }, [maxLength])
+
   const onCursorActivity = useCallback((editorWithActivity) => {
     setStatusBarInfo(createStatusInfo(editorWithActivity, maxLength))
   }, [maxLength])
+
   const codeMirrorOptions: EditorConfiguration = useMemo<EditorConfiguration>(() => ({
     ...editorPreferences,
     mode: 'gfm',

--- a/src/components/editor/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor/editor-pane/status-bar/status-bar.tsx
@@ -10,6 +10,7 @@ export interface StatusBarInfo {
   selectedLines: number
   linesInDocument: number
   charactersInDocument: number
+  remainingCharacters: number
 }
 
 export const defaultState: StatusBarInfo = {
@@ -17,18 +18,20 @@ export const defaultState: StatusBarInfo = {
   selectedColumns: 0,
   selectedLines: 0,
   linesInDocument: 0,
-  charactersInDocument: 0
+  charactersInDocument: 0,
+  remainingCharacters: 0
 }
 
-export const createStatusInfo = (editor: Editor): StatusBarInfo => ({
+export const createStatusInfo = (editor: Editor, maxDocumentLength: number): StatusBarInfo => ({
   position: editor.getCursor(),
   charactersInDocument: editor.getValue().length,
+  remainingCharacters: maxDocumentLength - editor.getValue().length,
   linesInDocument: editor.lineCount(),
   selectedColumns: editor.getSelection().length,
   selectedLines: editor.getSelection().split('\n').length
 })
 
-export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, selectedLines, charactersInDocument, linesInDocument }) => {
+export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, selectedLines, charactersInDocument, linesInDocument, remainingCharacters }) => {
   const { t } = useTranslation()
 
   return (
@@ -47,6 +50,7 @@ export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, 
       <div className="ml-auto">
         <span>{t('editor.statusBar.lines', { lines: linesInDocument })}</span>
         <span title={t('editor.statusBar.lengthTooltip')}>&nbsp;–&nbsp;{t('editor.statusBar.length', { length: charactersInDocument })}</span>
+        <span>&nbsp;-&nbsp;Remaining: { remainingCharacters }</span>
       </div>
     </div>
   )

--- a/src/components/editor/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor/editor-pane/status-bar/status-bar.tsx
@@ -49,8 +49,10 @@ export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, 
       </div>
       <div className="ml-auto">
         <span>{t('editor.statusBar.lines', { lines: linesInDocument })}</span>
-        <span title={t('editor.statusBar.lengthTooltip')}>&nbsp;–&nbsp;{t('editor.statusBar.length', { length: charactersInDocument })}</span>
-        <span>&nbsp;-&nbsp;Remaining: { remainingCharacters }</span>
+        <span
+          title={t('editor.statusBar.lengthTooltip', { remaining: remainingCharacters })}>
+          &nbsp;–&nbsp;{t('editor.statusBar.length', { length: charactersInDocument })}
+        </span>
       </div>
     </div>
   )

--- a/src/components/editor/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor/editor-pane/status-bar/status-bar.tsx
@@ -49,9 +49,12 @@ export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, 
       </div>
       <div className="ml-auto">
         <span>{t('editor.statusBar.lines', { lines: linesInDocument })}</span>
+        &nbsp;–&nbsp;
         <span
-          title={t('editor.statusBar.lengthTooltip', { remaining: remainingCharacters })}>
-          &nbsp;–&nbsp;{t('editor.statusBar.length', { length: charactersInDocument })}
+          title={t('editor.statusBar.lengthTooltip', { remaining: remainingCharacters })}
+          className={remainingCharacters <= 0 ? 'text-danger' : remainingCharacters <= 100 ? 'text-warning' : ''}
+        >
+          {t('editor.statusBar.length', { length: charactersInDocument })}
         </span>
       </div>
     </div>

--- a/src/components/editor/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor/editor-pane/status-bar/status-bar.tsx
@@ -1,5 +1,5 @@
 import { Editor, Position } from 'codemirror'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ShowIf } from '../../../common/show-if/show-if'
 import './status-bar.scss'
@@ -34,6 +34,16 @@ export const createStatusInfo = (editor: Editor, maxDocumentLength: number): Sta
 export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, selectedLines, charactersInDocument, linesInDocument, remainingCharacters }) => {
   const { t } = useTranslation()
 
+  const getLengthTooltip = useMemo(() => {
+    if (remainingCharacters === 0) {
+      return t('editor.statusBar.lengthTooltip.maximumReached')
+    }
+    if (remainingCharacters < 0) {
+      return t('editor.statusBar.lengthTooltip.exceeded', { exceeded: -remainingCharacters })
+    }
+    return t('editor.statusBar.lengthTooltip.remaining', { remaining: remainingCharacters })
+  }, [remainingCharacters, t])
+
   return (
     <div className="d-flex flex-row status-bar px-2">
       <div>
@@ -51,7 +61,7 @@ export const StatusBar: React.FC<StatusBarInfo> = ({ position, selectedColumns, 
         <span>{t('editor.statusBar.lines', { lines: linesInDocument })}</span>
         &nbsp;–&nbsp;
         <span
-          title={t('editor.statusBar.lengthTooltip', { remaining: remainingCharacters })}
+          title={getLengthTooltip}
           className={remainingCharacters <= 0 ? 'text-danger' : remainingCharacters <= 100 ? 'text-warning' : ''}
         >
           {t('editor.statusBar.length', { length: charactersInDocument })}

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -31,6 +31,7 @@ export const initialState: Config = {
     oauth2: '',
     saml: ''
   },
+  maxDocumentLength: 0,
   useImageProxy: false,
   plantumlServer: null,
   specialLinks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,6 +4344,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-commands@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cypress-commands/-/cypress-commands-1.1.0.tgz#9248190168783deb8ab27ae7c722e3e01d172c97"
+  integrity sha512-Q8Jr25pHJQFXwln6Hp8O+Hgs8Z506Y2wA9F1Te2cTajjc5L9gtt9WPOcw1Ogh+OgyqaMHF+uq31vdfImRTio5Q==
+
 cypress@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.1.0.tgz#979e9ff3e0acd792eefd365bf104046479a9643b"


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR adds support for setting a maximal document length and showing warning modals and information if the note is longer than the limit.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
<!-- e.g #123 -->
