### PR TITLE
Replace MathJax with KaTeX in our test note-content

### DIFF
--- a/src/components/editor/editorTestContent.ts
+++ b/src/components/editor/editorTestContent.ts
@@ -79,8 +79,8 @@ smith79;5079;Jamie;Smith
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 
-## MathJax
-You can render *LaTeX* mathematical expressions using **MathJax**, as on [math.stackexchange.com](https://math.stackexchange.com/):
+## KaTeX
+You can render *LaTeX* mathematical expressions using **KaTeX**, as on [math.stackexchange.com](https://math.stackexchange.com/):
 
 The *Gamma function* satisfying $\\Gamma(n) = (n-1)!\\quad\\forall n\\in\\mathbb N$ is via the Euler integral
 


### PR DESCRIPTION
### Component/Part
Editor -> Test content

### Description
This PR replaces the word MathJax with KaTeX in our test content as we don't use MathJax anymore for processing the formulas.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests _(nothing to change here)_
- [ ] added / updated documentation _(nothing to change here)_
- [ ] extended changelog _(nothing to change here as the change to KaTeX itself was written down already)_

### Related Issue(s)
#497 
