### PR TITLE
replace allowedChars with not-whitespace

### DIFF
--- a/src/components/editor/editor-pane/autocompletion/code-block.ts
+++ b/src/components/editor/editor-pane/autocompletion/code-block.ts
@@ -1,14 +1,13 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter, search } from './index'
 
-const allowedChars = /[`\w-_+]/
 const wordRegExp = /^```((\w|-|_|\+)*)$/
 let allSupportedLanguages: string[] = []
 
 const codeBlockHint = (editor: Editor): Promise< Hints| null > => {
   return import(/* webpackChunkName: "highlight.js" */ 'highlight.js').then(hljs =>
     new Promise((resolve) => {
-      const searchTerm = findWordAtCursor(editor, allowedChars)
+      const searchTerm = findWordAtCursor(editor)
       const searchResult = wordRegExp.exec(searchTerm.text)
       if (searchResult === null) {
         resolve(null)
@@ -36,7 +35,6 @@ const codeBlockHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const CodeBlockHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: codeBlockHint
 }

--- a/src/components/editor/editor-pane/autocompletion/collapsable-block.ts
+++ b/src/components/editor/editor-pane/autocompletion/collapsable-block.ts
@@ -1,12 +1,11 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedChars = /[<\w>]/
 const wordRegExp = /^(<d(?:e|et|eta|etai|etail|etails)?)$/
 
 const collapsableBlockHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -29,7 +28,6 @@ const collapsableBlockHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const CollapsableBlockHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: collapsableBlockHint
 }

--- a/src/components/editor/editor-pane/autocompletion/container.ts
+++ b/src/components/editor/editor-pane/autocompletion/container.ts
@@ -1,13 +1,12 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedChars = /[:\w-_+]/
 const wordRegExp = /^:::((\w|-|_|\+)*)$/
 const allSupportedConatiner = ['success', 'info', 'warning', 'danger']
 
 const containerHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -31,7 +30,6 @@ const containerHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const ContainerHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: containerHint
 }

--- a/src/components/editor/editor-pane/autocompletion/emoji.ts
+++ b/src/components/editor/editor-pane/autocompletion/emoji.ts
@@ -5,13 +5,12 @@ import { customEmojis } from '../tool-bar/emoji-picker/emoji-picker'
 import { getEmojiIcon, getEmojiShortCode } from '../tool-bar/utils/emojiUtils'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedCharsInEmojiCodeRegex = /[:\w-_+]/
 const emojiIndex = new NimbleEmojiIndex(data as unknown as Data)
 const emojiWordRegex = /^:([\w-_+]*)$/
 
 const generateEmojiHints = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedCharsInEmojiCodeRegex)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = emojiWordRegex.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -50,7 +49,6 @@ const generateEmojiHints = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const EmojiHinter: Hinter = {
-  allowedChars: allowedCharsInEmojiCodeRegex,
   wordRegExp: emojiWordRegex,
   hint: generateEmojiHints
 }

--- a/src/components/editor/editor-pane/autocompletion/header.ts
+++ b/src/components/editor/editor-pane/autocompletion/header.ts
@@ -1,14 +1,13 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter, search } from './index'
 
-const allowedChars = /#/
 const wordRegExp = /^(\s{0,3})(#{1,6})$/
 const allSupportedHeaders = ['# h1', '## h2', '### h3', '#### h4', '##### h5', '###### h6', '###### tags: `example`']
 const allSupportedHeadersTextToInsert = ['# ', '## ', '### ', '#### ', '##### ', '###### ', '###### tags: `example`']
 
 const headerHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -25,8 +24,8 @@ const headerHint = (editor: Editor): Promise< Hints| null > => {
       resolve(null)
     } else {
       resolve({
-        list: suggestions.map((suggestion, index): Hint => ({
-          text: allSupportedHeadersTextToInsert[index],
+        list: suggestions.map((suggestion): Hint => ({
+          text: allSupportedHeadersTextToInsert[allSupportedHeaders.indexOf(suggestion)],
           displayText: suggestion
         })),
         from: Pos(cursor.line, searchTerm.start),
@@ -37,7 +36,6 @@ const headerHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const HeaderHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: headerHint
 }

--- a/src/components/editor/editor-pane/autocompletion/image.ts
+++ b/src/components/editor/editor-pane/autocompletion/image.ts
@@ -1,7 +1,6 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedChars = /[![\]\w]/
 const wordRegExp = /^(!(\[.*])?)$/
 const allSupportedImages = [
   '![image alt](https:// "title")',
@@ -11,7 +10,7 @@ const allSupportedImages = [
 
 const imageHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -34,7 +33,6 @@ const imageHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const ImageHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: imageHint
 }

--- a/src/components/editor/editor-pane/autocompletion/index.ts
+++ b/src/components/editor/editor-pane/autocompletion/index.ts
@@ -19,12 +19,13 @@ export interface Hinter {
   hint: (editor: Editor) => Promise< Hints| null >
 }
 
+const allowedChars = /[^ ]/
+
 export const findWordAtCursor = (editor: Editor): findWordAtCursorResponse => {
   const cursor = editor.getCursor()
   const line = editor.getLine(cursor.line)
   let start = cursor.ch
   let end = cursor.ch
-  const allowedChars = /[^ ]/
   while (start && allowedChars.test(line.charAt(start - 1))) {
     --start
   }

--- a/src/components/editor/editor-pane/autocompletion/index.ts
+++ b/src/components/editor/editor-pane/autocompletion/index.ts
@@ -19,7 +19,7 @@ export interface Hinter {
   hint: (editor: Editor) => Promise< Hints| null >
 }
 
-const allowedChars = /[^ ]/
+const allowedChars = /[^\s]/
 
 export const findWordAtCursor = (editor: Editor): findWordAtCursorResponse => {
   const cursor = editor.getCursor()

--- a/src/components/editor/editor-pane/autocompletion/index.ts
+++ b/src/components/editor/editor-pane/autocompletion/index.ts
@@ -15,16 +15,16 @@ interface findWordAtCursorResponse {
 }
 
 export interface Hinter {
-  allowedChars: RegExp,
   wordRegExp: RegExp,
   hint: (editor: Editor) => Promise< Hints| null >
 }
 
-export const findWordAtCursor = (editor: Editor, allowedChars: RegExp): findWordAtCursorResponse => {
+export const findWordAtCursor = (editor: Editor): findWordAtCursorResponse => {
   const cursor = editor.getCursor()
   const line = editor.getLine(cursor.line)
   let start = cursor.ch
   let end = cursor.ch
+  const allowedChars = /[^ ]/
   while (start && allowedChars.test(line.charAt(start - 1))) {
     --start
   }

--- a/src/components/editor/editor-pane/autocompletion/link-and-extra-tag.ts
+++ b/src/components/editor/editor-pane/autocompletion/link-and-extra-tag.ts
@@ -3,7 +3,6 @@ import moment from 'moment'
 import { getUser } from '../../../../redux/user/methods'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedChars = /[[\]\w]/
 const wordRegExp = /^(\[(.*])?)$/
 const allSupportedLinks = [
   '[link text](https:// "title")',
@@ -22,7 +21,7 @@ const allSupportedLinks = [
 
 const linkAndExtraTagHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -63,7 +62,6 @@ const linkAndExtraTagHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const LinkAndExtraTagHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: linkAndExtraTagHint
 }

--- a/src/components/editor/editor-pane/autocompletion/pdf.ts
+++ b/src/components/editor/editor-pane/autocompletion/pdf.ts
@@ -1,12 +1,11 @@
 import { Editor, Hint, Hints, Pos } from 'codemirror'
 import { findWordAtCursor, Hinter } from './index'
 
-const allowedChars = /[{%]/
 const wordRegExp = /^({[%}]?)$/
 
 const pdfHint = (editor: Editor): Promise< Hints| null > => {
   return new Promise((resolve) => {
-    const searchTerm = findWordAtCursor(editor, allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     const searchResult = wordRegExp.exec(searchTerm.text)
     if (searchResult === null) {
       resolve(null)
@@ -29,7 +28,6 @@ const pdfHint = (editor: Editor): Promise< Hints| null > => {
 }
 
 export const PDFHinter: Hinter = {
-  allowedChars,
   wordRegExp,
   hint: pdfHint
 }

--- a/src/components/editor/editor-pane/editor-pane.tsx
+++ b/src/components/editor/editor-pane/editor-pane.tsx
@@ -41,7 +41,7 @@ export interface EditorPaneProps {
 
 const onChange = (editor: Editor) => {
   for (const hinter of allHinters) {
-    const searchTerm = findWordAtCursor(editor, hinter.allowedChars)
+    const searchTerm = findWordAtCursor(editor)
     if (hinter.wordRegExp.test(searchTerm.text)) {
       editor.showHint({
         hint: hinter.hint,


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR changes the auto completion behaviour. Auto completion will only react for words that are separated by space (or space like characters)

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
Closes #593 
