### PR TITLE
fixed help modal width

### DIFF
--- a/src/components/editor/app-bar/help-button/help-button.tsx
+++ b/src/components/editor/app-bar/help-button/help-button.tsx
@@ -30,14 +30,14 @@ export const HelpButton: React.FC = () => {
 
   return (
     <Fragment>
-      <Button title={t('editor.documentBar.help')} className="ml-2 text-secondary" size="sm" variant="outline-light"
+      <Button title={t('editor.documentBar.help')} className='ml-2 text-secondary' size='sm' variant='outline-light'
         onClick={() => setShow(true)}>
         <ForkAwesomeIcon icon="question-circle"/>
       </Button>
-      <Modal show={show} onHide={() => setShow(false)} animation={true} className="text-dark" size='xl'>
+      <Modal show={show} onHide={() => setShow(false)} animation={true} className='text-dark' size='lg'>
         <Modal.Header closeButton>
           <Modal.Title>
-            <ForkAwesomeIcon icon="question-circle"/> <Trans i18nKey={'editor.documentBar.help'}/> – <Trans i18nKey={`editor.help.${tab}`}/>
+            <ForkAwesomeIcon icon='question-circle'/> <Trans i18nKey={'editor.documentBar.help'}/> – <Trans i18nKey={`editor.help.${tab}`}/>
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>


### PR DESCRIPTION
### Component/Part
help modal

### Description
This PR fixed the size of the help modal.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### addtional infos
after we added tabs in the help modal, the modal doesn't need to be xl anymore as it has way to much empty space that way.
