### PR TITLE
added js as an extra highlighted language

### DIFF
--- a/src/components/editor/editor-pane/autocompletion/code-block.ts
+++ b/src/components/editor/editor-pane/autocompletion/code-block.ts
@@ -15,7 +15,7 @@ const codeBlockHint = (editor: Editor): Promise< Hints| null > => {
       }
       const term = searchResult[1]
       if (allSupportedLanguages.length === 0) {
-        allSupportedLanguages = hljs.listLanguages().concat('csv', 'flow', 'html')
+        allSupportedLanguages = hljs.listLanguages().concat('csv', 'flow', 'html', 'js', 'markmap', 'abc', 'graphviz', 'mermaid', 'vega-lite')
       }
       const suggestions = search(term, allSupportedLanguages)
       const cursor = editor.getCursor()

--- a/src/components/editor/editorTestContent.ts
+++ b/src/components/editor/editorTestContent.ts
@@ -230,7 +230,7 @@ https://asciinema.org/a/117928
 {%pdf https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf %}
 
 ## Code highlighting
-\`\`\`javascript=
+\`\`\`js=
 var s = "JavaScript syntax highlighting";
 alert(s);
 function $initHighlight(block, cls) {

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
@@ -24,6 +24,8 @@ const correctLanguage = (language: string | undefined): string | undefined => {
   switch (language) {
     case 'html':
       return 'xml'
+    case 'js':
+      return 'javascript'
     default:
       return language
   }


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR adds js as an extra highlight language. Also the auto completion show all diagrams and extra languages we support. 

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
fixes #258
