### PR TITLE
Add access token management to profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - The <i class="fa fa-picture-o"/> (add image) and <i class="fa fa-link"/> (add link) toolbar buttons, put selected links directly in the `()` instead of the `[]` part of the generated markdown
 - The help dialog has multiple tabs, and is a bit more organized.
 - Use KaTeX instead of MathJax. ([Why?](https://community.codimd.org/t/frequently-asked-questions/190))
-- The CLI and 3rd-party-clients now rely on access tokens, they can be managed in the user profile.
+- The access tokens for the CLI and 3rd-party-clients can be managed in the user profile.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - The <i class="fa fa-picture-o"/> (add image) and <i class="fa fa-link"/> (add link) toolbar buttons, put selected links directly in the `()` instead of the `[]` part of the generated markdown
 - The help dialog has multiple tabs, and is a bit more organized.
 - Use KaTeX instead of MathJax. ([Why?](https://community.codimd.org/t/frequently-asked-questions/190))
+- The CLI and 3rd-party-clients now rely on access tokens, they can be managed in the user profile.
 
 ---
 

--- a/cypress/integration/profile.spec.ts
+++ b/cypress/integration/profile.spec.ts
@@ -1,0 +1,61 @@
+describe('profile page', () => {
+  beforeEach(() => {
+    cy.route({
+      url: '/api/v2/tokens',
+      method: 'GET',
+      response: [
+        {
+          label: "cypress-App",
+          created: 1601991518
+        }
+      ]
+    })
+    cy.route({
+      url: '/api/v2/tokens',
+      method: 'POST',
+      response: {
+        label: 'cypress',
+        secret: 'c-y-p-r-e-s-s',
+        created: Date.now()
+      }
+    })
+    cy.route({
+      url: '/api/v2/tokens/1601991518',
+      method: 'DELETE',
+      response: []
+    })
+    cy.visit('/profile')
+  })
+
+  describe('access tokens', () => {
+    it('list existing tokens', () => {
+      cy.get('.card.access-tokens .list-group-item .text-start.col')
+        .contains('cypress-App')
+    })
+
+    it('delete token', () => {
+      cy.get('.card.access-tokens .list-group-item .btn-danger')
+        .click()
+      cy.get('.modal-dialog')
+        .should('be.visible')
+        .get('.modal-footer .btn-danger')
+        .click()
+      cy.get('.modal-dialog')
+        .should('not.be.visible')
+    })
+
+    it('add token', () => {
+      cy.get('.card.access-tokens .btn-primary')
+        .should('be.disabled')
+      cy.get('.card.access-tokens input[type=text]')
+        .type('cypress')
+      cy.get('.card.access-tokens .btn-primary')
+        .should('not.be.disabled')
+        .click()
+      cy.get('.modal-dialog')
+        .should('be.visible')
+        .get('.modal-dialog input[readonly]')
+        .should('have.value', 'c-y-p-r-e-s-s')
+    })
+  })
+})

--- a/public/api/v2/tokens
+++ b/public/api/v2/tokens
@@ -1,0 +1,10 @@
+[
+    {
+        "label": "Demo-App",
+        "created": 1601991518
+    },
+    {
+        "label": "CLI @ Test-PC",
+        "created": 1601912159
+    }
+]

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -151,8 +151,8 @@
         "accessTokens": {
             "title": "Access tokens",
             "info": "Access tokens can be used to grant the CLI or third-party applications access to your account.",
-            "infoDev": "Developers can use access tokens to access the public API.",
-            "noTokens": "You don't have any access tokens generated yet.",
+            "infoDev": "Developers can use these to access the public API.",
+            "noTokens": "You don't have any tokens generated yet.",
             "createToken": "Create token",
             "label": "Token label",
             "created": "created {{time}}"
@@ -164,11 +164,11 @@
                 "subMessage": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes."
             },
             "addedAccessToken": {
-                "title": "Access token added",
+                "title": "Token added",
                 "message": "An access token was created. Copy it from the field below now, as you won't be able to view it again."
             },
             "deleteAccessToken": {
-                "title": "Really delete access token?",
+                "title": "Really delete token?",
                 "message": "When deleting an access token, the applications that used it won't have access to your account anymore. You eventually need a new token to continue using those applications."
             }
         }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -148,11 +148,23 @@
         "accountManagement": "Account management",
         "deleteUser": "Delete user",
         "exportUserData": "Export user data",
+        "accessTokens": {
+            "title": "Access tokens",
+            "info": "Access tokens can be used to grant the CLI or third-party applications access to your account.",
+            "infoDev": "Developers can use access tokens to access the public API.",
+            "noTokens": "You don't have any access tokens generated yet.",
+            "createToken": "Create token",
+            "label": "Token label",
+            "created": "created {{time}}"
+        },
         "modal": {
             "deleteUser": {
                 "title": "Delete user",
                 "message": "Do you really want to delete your user account?",
                 "subMessage": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes."
+            },
+            "addAccessToken": {
+                "title": "Add access token"
             }
         }
     },
@@ -384,7 +396,8 @@
         "avatarOf": "avatar of '{{name}}'",
         "why": "Why?",
         "successfullyCopied": "Copied!",
-        "copyError": "Error while copying!"
+        "copyError": "Error while copying!",
+        "errorOccurred": "An error occurred"
     },
     "login": {
         "chooseMethod": "Choose method",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -150,7 +150,7 @@
         "exportUserData": "Export user data",
         "accessTokens": {
             "title": "Access tokens",
-            "info": "Access tokens can be used to grant the CLI or third-party applications access to your account.",
+            "info": "Access tokens are an password-less authentication method for the CLI or third-party applications.",
             "infoDev": "Developers can use these to access the public API.",
             "noTokens": "You don't have any tokens generated yet.",
             "createToken": "Create token",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -166,6 +166,10 @@
             "addedAccessToken": {
                 "title": "Access token added",
                 "message": "An access token was created. Copy it from the field below now, as you won't be able to view it again."
+            },
+            "deleteAccessToken": {
+                "title": "Really delete access token?",
+                "message": "When deleting an access token, the applications that used it won't have access to your account anymore. You eventually need a new token to continue using those applications."
             }
         }
     },
@@ -392,6 +396,7 @@
         "ok": "OK",
         "close": "Close",
         "save": "Save",
+        "delete": "Delete",
         "or": "or",
         "and": "and",
         "avatarOf": "avatar of '{{name}}'",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -163,8 +163,9 @@
                 "message": "Do you really want to delete your user account?",
                 "subMessage": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes."
             },
-            "addAccessToken": {
-                "title": "Add access token"
+            "addedAccessToken": {
+                "title": "Access token added",
+                "message": "An access token was created. Copy it from the field below now, as you won't be able to view it again."
             }
         }
     },

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -1,0 +1,10 @@
+import { defaultFetchConfig, expectResponseCode, getApiUrl } from '../utils'
+import { AccessToken } from './types'
+
+export const getAccessTokenList = async (): Promise<AccessToken[]> => {
+  const response = await fetch(`${getApiUrl()}/tokens`, {
+    ...defaultFetchConfig
+  })
+  expectResponseCode(response)
+  return await response.json() as AccessToken[]
+}

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -10,18 +10,13 @@ export const getAccessTokenList = async (): Promise<AccessToken[]> => {
 }
 
 export const postNewAccessToken = async (label: string): Promise<AccessToken & AccessTokenSecret> => {
-  // const response = await fetch(`${getApiUrl()}/tokens`, {
-  //   ...defaultFetchConfig,
-  //   method: 'POST',
-  //   body: label
-  // })
-  // expectResponseCode(response)
-  // return await response.json() as (AccessToken & AccessTokenSecret)
-  return {
-    label: label,
-    secret: 'abc-123-def-456',
-    created: Math.floor(Date.now())
-  }
+  const response = await fetch(`${getApiUrl()}/tokens`, {
+    ...defaultFetchConfig,
+    method: 'POST',
+    body: label
+  })
+  expectResponseCode(response)
+  return await response.json() as (AccessToken & AccessTokenSecret)
 }
 
 export const deleteAccessToken = async (timestamp: number): Promise<void> => {

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -23,3 +23,11 @@ export const postNewAccessToken = async (label: string): Promise<AccessToken & A
     created: Math.floor(Date.now())
   }
 }
+
+export const deleteAccessToken = async (timestamp: number): Promise<void> => {
+  const response = await fetch(`${getApiUrl()}/tokens/${timestamp}`, {
+    ...defaultFetchConfig,
+    method: 'DELETE'
+  })
+  expectResponseCode(response)
+}

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -1,5 +1,5 @@
 import { defaultFetchConfig, expectResponseCode, getApiUrl } from '../utils'
-import { AccessToken } from './types'
+import { AccessToken, AccessTokenSecret } from './types'
 
 export const getAccessTokenList = async (): Promise<AccessToken[]> => {
   const response = await fetch(`${getApiUrl()}/tokens`, {
@@ -7,4 +7,19 @@ export const getAccessTokenList = async (): Promise<AccessToken[]> => {
   })
   expectResponseCode(response)
   return await response.json() as AccessToken[]
+}
+
+export const postNewAccessToken = async (label: string): Promise<AccessToken & AccessTokenSecret> => {
+  // const response = await fetch(`${getApiUrl()}/tokens`, {
+  //   ...defaultFetchConfig,
+  //   method: 'POST',
+  //   body: label
+  // })
+  // expectResponseCode(response)
+  // return await response.json() as (AccessToken & AccessTokenSecret)
+  return {
+    label: label,
+    secret: 'abc-123-def-456',
+    created: Math.floor(Date.now())
+  }
 }

--- a/src/api/tokens/types.d.ts
+++ b/src/api/tokens/types.d.ts
@@ -1,0 +1,8 @@
+export interface AccessToken {
+  label: string
+  created: number
+}
+
+export interface AccessTokenSecret {
+  secret: string
+}

--- a/src/components/common/icon-button/icon-button.tsx
+++ b/src/components/common/icon-button/icon-button.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonProps } from 'react-bootstrap'
 import { ForkAwesomeIcon } from '../fork-awesome/fork-awesome-icon'
 import { IconName } from '../fork-awesome/types'
 import './icon-button.scss'
+import { ShowIf } from '../show-if/show-if'
 
 export interface IconButtonProps extends ButtonProps {
   icon: IconName
@@ -16,9 +17,11 @@ export const IconButton: React.FC<IconButtonProps> = ({ icon, children, border =
       <span className="icon-part d-flex align-items-center">
         <ForkAwesomeIcon icon={icon} className={'icon'}/>
       </span>
-      <span className="text-part d-flex align-items-center">
-        {children}
-      </span>
+      <ShowIf condition={!!children}>
+        <span className="text-part d-flex align-items-center">
+          {children}
+        </span>
+      </ShowIf>
     </Button>
   )
 }

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -1,0 +1,129 @@
+import { DateTime } from 'luxon'
+import React, { ChangeEvent, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import { Button, Card, Col, Form, ListGroup, Modal, Row } from 'react-bootstrap'
+import { Trans, useTranslation } from 'react-i18next'
+import { getAccessTokenList } from '../../../api/tokens'
+import { AccessToken } from '../../../api/tokens/types'
+import { IconButton } from '../../common/icon-button/icon-button'
+import { CommonModal } from '../../common/modals/common-modal'
+import { DeletionModal } from '../../common/modals/deletion-modal'
+import { ShowIf } from '../../common/show-if/show-if'
+
+export const ProfileAccessTokens: React.FC = () => {
+  const { t } = useTranslation()
+
+  const [error, setError] = useState(false)
+  const [showAddedModal, setShowAddedModal] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [accessTokens, setAccessTokens] = useState<AccessToken[]>([])
+  const [newTokenLabel, setNewTokenLabel] = useState('')
+
+  const addToken = useCallback(() => {
+    // TODO Handle logic for adding an access token
+  }, [])
+
+  const deleteToken = useCallback(() => {
+    // TODO Handle logic for removing an existing access token
+  }, [])
+
+  const newTokenSubmittable = useMemo(() => {
+    return newTokenLabel.trim().length > 0
+  }, [newTokenLabel])
+
+  useEffect(() => {
+    getAccessTokenList()
+      .then(tokens => {
+        setError(false)
+        setAccessTokens(tokens)
+      })
+      .catch(err => {
+        console.error(err)
+        setError(true)
+      })
+  }, [])
+
+  return (
+    <Fragment>
+      <Card className='bg-dark mb-4'>
+        <Card.Body>
+          <Card.Title>
+            <Trans i18nKey='profile.accessTokens.title'/>
+          </Card.Title>
+          <p className='text-start'><Trans i18nKey='profile.accessTokens.info'/></p>
+          <p className='text-start small'><Trans i18nKey='profile.accessTokens.infoDev'/></p>
+          <hr/>
+          <ShowIf condition={accessTokens.length === 0 && !error}>
+            <Trans i18nKey='profile.accessTokens.noTokens'/>
+          </ShowIf>
+          <ShowIf condition={error}>
+            <Trans i18nKey='common.errorOccurred'/>
+          </ShowIf>
+          <ListGroup>
+            {
+              accessTokens.map((token, index) => {
+                return (
+                  <ListGroup.Item className='bg-dark' key={index}>
+                    <Row>
+                      <Col className='text-start'>
+                        { token.label }
+                      </Col>
+                      <Col className='text-start text-white-50'>
+                        <Trans i18nKey='profile.accessTokens.created' values={{
+                          time: DateTime.fromSeconds(token.created).toRelative({
+                            style: 'short'
+                          })
+                        }}/>
+                      </Col>
+                      <Col xs='auto'>
+                        <IconButton icon='trash-o' variant='danger'/>
+                      </Col>
+                    </Row>
+                  </ListGroup.Item>
+                )
+              })
+            }
+          </ListGroup>
+          <hr/>
+          <Form onSubmit={addToken} className='text-left'>
+            <Form.Row>
+              <Col>
+                <Form.Control
+                  type='text'
+                  size='sm'
+                  placeholder={t('profile.accessTokens.label')}
+                  value={newTokenLabel}
+                  className='bg-dark text-light'
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setNewTokenLabel(event.target.value)}
+                  isValid={newTokenSubmittable}
+                  required
+                />
+              </Col>
+              <Col xs={'auto'}>
+                <Button
+                  type='submit'
+                  variant='primary'
+                  size='sm'
+                  disabled={!newTokenSubmittable}>
+                  <Trans i18nKey='profile.accessTokens.createToken'/>
+                </Button>
+              </Col>
+            </Form.Row>
+          </Form>
+        </Card.Body>
+      </Card>
+
+      <CommonModal show={showAddedModal} onHide={() => setShowAddedModal(false)} titleI18nKey='profile.modals.addAccessToken.title'>
+        <Modal.Body>
+          1
+        </Modal.Body>
+        <Modal.Footer>
+          2
+        </Modal.Footer>
+      </CommonModal>
+
+      <DeletionModal onConfirm={deleteToken} deletionButtonI18nKey={''} show={showDeleteModal} onHide={() => setShowDeleteModal(false)}>
+        1
+      </DeletionModal>
+    </Fragment>
+  )
+}

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -72,7 +72,7 @@ export const ProfileAccessTokens: React.FC = () => {
 
   return (
     <Fragment>
-      <Card className='bg-dark mb-4'>
+      <Card className='bg-dark mb-4 access-tokens'>
         <Card.Body>
           <Card.Title>
             <Trans i18nKey='profile.accessTokens.title'/>

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -88,9 +88,9 @@ export const ProfileAccessTokens: React.FC = () => {
           </ShowIf>
           <ListGroup>
             {
-              accessTokens.map((token, index) => {
+              accessTokens.map((token) => {
                 return (
-                  <ListGroup.Item className='bg-dark' key={index}>
+                  <ListGroup.Item className='bg-dark' key={token.created}>
                     <Row>
                       <Col className='text-start'>
                         { token.label }

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -1,10 +1,12 @@
 import { DateTime } from 'luxon'
-import React, { ChangeEvent, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { ChangeEvent, FormEvent, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Card, Col, Form, ListGroup, Modal, Row } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
-import { getAccessTokenList } from '../../../api/tokens'
+import { getAccessTokenList, postNewAccessToken } from '../../../api/tokens'
 import { AccessToken } from '../../../api/tokens/types'
+import { CopyableField } from '../../common/copyable/copyable-field/copyable-field'
 import { IconButton } from '../../common/icon-button/icon-button'
+import { TranslatedIconButton } from '../../common/icon-button/translated-icon-button'
 import { CommonModal } from '../../common/modals/common-modal'
 import { DeletionModal } from '../../common/modals/deletion-modal'
 import { ShowIf } from '../../common/show-if/show-if'
@@ -17,10 +19,21 @@ export const ProfileAccessTokens: React.FC = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [accessTokens, setAccessTokens] = useState<AccessToken[]>([])
   const [newTokenLabel, setNewTokenLabel] = useState('')
+  const [newTokenSecret, setNewTokenSecret] = useState('')
 
-  const addToken = useCallback(() => {
-    // TODO Handle logic for adding an access token
-  }, [])
+  const addToken = useCallback((event: FormEvent) => {
+    event.preventDefault()
+    postNewAccessToken(newTokenLabel)
+      .then(token => {
+        setNewTokenSecret(token.secret)
+        setShowAddedModal(true)
+        setNewTokenLabel('')
+      })
+      .catch(error => {
+        console.error(error)
+        setError(true)
+      })
+  }, [newTokenLabel])
 
   const deleteToken = useCallback(() => {
     // TODO Handle logic for removing an existing access token
@@ -40,7 +53,7 @@ export const ProfileAccessTokens: React.FC = () => {
         console.error(err)
         setError(true)
       })
-  }, [])
+  }, [showAddedModal])
 
   return (
     <Fragment>
@@ -112,12 +125,16 @@ export const ProfileAccessTokens: React.FC = () => {
         </Card.Body>
       </Card>
 
-      <CommonModal show={showAddedModal} onHide={() => setShowAddedModal(false)} titleI18nKey='profile.modals.addAccessToken.title'>
+      <CommonModal show={showAddedModal} onHide={() => setShowAddedModal(false)} titleI18nKey='profile.modal.addedAccessToken.title'>
         <Modal.Body>
-          1
+          <Trans i18nKey='profile.modal.addedAccessToken.message'/>
+          <br/>
+          <CopyableField content={newTokenSecret}/>
         </Modal.Body>
         <Modal.Footer>
-          2
+          <Button variant='primary' onClick={() => setShowAddedModal(false)}>
+            <Trans i18nKey='common.close'/>
+          </Button>
         </Modal.Footer>
       </CommonModal>
 

--- a/src/components/profile-page/profile-page.tsx
+++ b/src/components/profile-page/profile-page.tsx
@@ -5,6 +5,7 @@ import { Redirect } from 'react-router'
 import { ApplicationState } from '../../redux'
 import { LoginProvider } from '../../redux/user/types'
 import { ShowIf } from '../common/show-if/show-if'
+import { ProfileAccessTokens } from './access-tokens/profile-access-tokens'
 import { ProfileAccountManagement } from './settings/profile-account-management'
 import { ProfileChangePassword } from './settings/profile-change-password'
 import { ProfileDisplayName } from './settings/profile-display-name'
@@ -26,6 +27,7 @@ export const ProfilePage: React.FC = () => {
           <ShowIf condition={userProvider === LoginProvider.INTERNAL}>
             <ProfileChangePassword/>
           </ShowIf>
+          <ProfileAccessTokens/>
           <ProfileAccountManagement/>
         </Col>
       </Row>


### PR DESCRIPTION
### Component/Part
Profile page

### Description
This PR adds the access token management section to the profile. I chose the wording "Access token" over "API key" as it sounds not that technical.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [x] added / updated tests
- [ ] added / updated documentation
- [x] extended changelog

### Additional information
![image](https://user-images.githubusercontent.com/52606896/95469999-8e222b80-0980-11eb-8fd9-3f2540cfee1f.png)


### Related Issue(s)
closes #647 
