### PR TITLE
Enforce no warnings during linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "build": "craco build",
         "analyze": "cross-env ANALYZE=true craco build",
         "test": "craco test",
-        "lint": "eslint --ext .ts,.tsx src",
+        "lint": "eslint --max-warnings=0 --ext .ts,.tsx src",
         "eject": "react-scripts eject",
         "cy:open": "cypress open",
         "cy:run:chrome": "cypress run --browser chrome",


### PR DESCRIPTION
### Component/Part
package.json scripts,  in turn CI linting job

### Description
This PR sets the maximum number of allowed warnings during linting to 0, thereby enforcing completely fine linted code.
I tested the change locally with a prepared code snippet.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [ ] added implementation
- [x] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
none
