### PR TITLE
Removed 'ago'-suffix from translations

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -329,8 +329,8 @@
             },
             "documentInfo": {
                 "title": "Document info",
-                "created": "<0></0> created this note <1></1> ago",
-                "edited": "<0></0> was the last editor <1></1> ago",
+                "created": "<0></0> created this note <1></1>",
+                "edited": "<0></0> was the last editor <1></1>",
                 "usersContributed": "<0></0> users contributed to this document",
                 "revisions": "<0></0> revisions are saved"
             },


### PR DESCRIPTION
### Component/Part
Translation files

### Description
moment.js had a flag that stripped these suffixes from their output, so that we could customize the messages more. luxon does not have this flag and therefore generates double suffixes.
This PR updates the translations to remove the additional suffix.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
none
