### PR TITLE
Disable check box if no onTaskCheckedChange is provided

### DIFF
--- a/src/components/markdown-renderer/full-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/full-markdown-renderer.tsx
@@ -19,7 +19,7 @@ export interface FullMarkdownRendererProps {
   onFirstHeadingChange?: (firstHeading: string | undefined) => void
   onLineMarkerPositionChanged?: (lineMarkerPosition: LineMarkerPosition[]) => void
   onMetaDataChange?: (yamlMetaData: YAMLMetaData | undefined) => void
-  onTaskCheckedChange: (lineInMarkdown: number, checked: boolean) => void
+  onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void
   onTocChange?: (ast: TocAst) => void
 }
 

--- a/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
+++ b/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
@@ -21,7 +21,7 @@ import { VegaReplacer } from '../replace-components/vega-lite/vega-replacer'
 import { VimeoReplacer } from '../replace-components/vimeo/vimeo-replacer'
 import { YoutubeReplacer } from '../replace-components/youtube/youtube-replacer'
 
-export const useReplacerInstanceListCreator = (onTaskCheckedChange: (lineInMarkdown: number, checked: boolean) => void): ()=>ComponentReplacer[] => {
+export const useReplacerInstanceListCreator = (onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void): () => ComponentReplacer[] => {
   return useMemo(() => () => [
     new LinemarkerReplacer(),
     new PossibleWiderReplacer(),

--- a/src/components/markdown-renderer/replace-components/task-list/task-list-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/task-list/task-list-replacer.tsx
@@ -1,31 +1,35 @@
-import React, { ReactElement } from 'react'
 import { DomElement } from 'domhandler'
+import React, { ReactElement } from 'react'
 import { ComponentReplacer } from '../ComponentReplacer'
 
 export class TaskListReplacer extends ComponentReplacer {
-  onTaskCheckedChange: (lineInMarkdown: number, checked: boolean) => void
+  onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void
 
-  constructor (onTaskCheckedChange: (lineInMarkdown: number, checked: boolean) => void) {
+  constructor (onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void) {
     super()
     this.onTaskCheckedChange = onTaskCheckedChange
   }
 
   handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const lineNum = Number(event.currentTarget.dataset.line)
-    this.onTaskCheckedChange(lineNum, event.currentTarget.checked)
+    if (this.onTaskCheckedChange) {
+      this.onTaskCheckedChange(lineNum, event.currentTarget.checked)
+    }
   }
 
-  public getReplacement (node: DomElement): (ReactElement|undefined) {
-    if (node.attribs?.class === 'task-list-item-checkbox') {
-      return (
-        <input
-          className="task-list-item-checkbox"
-          type="checkbox"
-          checked={node.attribs.checked !== undefined}
-          onChange={this.handleCheckboxChange}
-          data-line={node.attribs['data-line']}
-        />
-      )
+  public getReplacement (node: DomElement): (ReactElement | undefined) {
+    if (node.attribs?.class !== 'task-list-item-checkbox') {
+      return
     }
+    return (
+      <input
+        disabled={this.onTaskCheckedChange === undefined}
+        className="task-list-item-checkbox"
+        type="checkbox"
+        checked={node.attribs.checked !== undefined}
+        onChange={this.handleCheckboxChange}
+        data-line={node.attribs['data-line']}
+      />
+    )
   }
 }


### PR DESCRIPTION
### Component/Part
Markdown renderer > Task Lists

### Description
This PR improves the task lists replacer. If no onTaskCheckedChange callback was provided, then the checkboxes will be disabled.

### Steps

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog
