### PR TITLE
Use bare version of markdown-it-emoji

### DIFF
--- a/src/components/markdown-renderer/markdown-it-plugins/twitter-emojis.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/twitter-emojis.ts
@@ -1,5 +1,5 @@
 import MarkdownIt from 'markdown-it'
-import emoji from 'markdown-it-emoji'
+import emoji from 'markdown-it-emoji/bare'
 import { combinedEmojiData } from './emoji/mapping'
 
 export const twitterEmojis: MarkdownIt.PluginSimple = (markdownIt) => {

--- a/src/external-types/markdown-it-emoji/index.d.ts
+++ b/src/external-types/markdown-it-emoji/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'markdown-it-emoji' {
+declare module 'markdown-it-emoji/bare' {
   import MarkdownIt from 'markdown-it/lib'
   import { EmojiOptions } from './interface'
   const markdownItEmoji: MarkdownIt.PluginWithOptions<EmojiOptions>


### PR DESCRIPTION
### Component/Part
Emoji replacer

### Description
This PR replaces the used markdown it emoji plugin with the bare version, so it won't include an emoji definition.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
<!-- e.g #123 -->
