### PR TITLE
moved alertContainer to basic renderer from full renderer

### DIFF
--- a/src/components/editor/app-bar/help-button/cheatsheet.tsx
+++ b/src/components/editor/app-bar/help-button/cheatsheet.tsx
@@ -3,7 +3,6 @@ import { Table } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { BasicMarkdownRenderer } from '../../../markdown-renderer/basic-markdown-renderer'
 import { BasicMarkdownItConfigurator } from '../../../markdown-renderer/markdown-it-configurator/BasicMarkdownItConfigurator'
-import { alertContainer } from '../../../markdown-renderer/markdown-it-plugins/alert-container'
 import { HighlightedCode } from '../../../markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code'
 import './cheatsheet.scss'
 
@@ -32,7 +31,6 @@ export const Cheatsheet: React.FC = () => {
 
   const markdownIt = useMemo(() => {
     return new BasicMarkdownItConfigurator()
-      .pushConfig(alertContainer)
       .buildConfiguredMarkdownIt()
   }, [])
 

--- a/src/components/markdown-renderer/markdown-it-configurator/BasicMarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/BasicMarkdownItConfigurator.tsx
@@ -7,6 +7,7 @@ import inserted from 'markdown-it-ins'
 import marked from 'markdown-it-mark'
 import subscript from 'markdown-it-sub'
 import superscript from 'markdown-it-sup'
+import { alertContainer } from '../markdown-it-plugins/alert-container'
 import { linkifyExtra } from '../markdown-it-plugins/linkify-extra'
 import { MarkdownItParserDebugger } from '../markdown-it-plugins/parser-debugger'
 import { twitterEmojis } from '../markdown-it-plugins/twitter-emojis'
@@ -23,7 +24,8 @@ export class BasicMarkdownItConfigurator extends MarkdownItConfigurator {
       inserted,
       marked,
       footnote,
-      imsize
+      imsize,
+      alertContainer
     )
     this.postConfigurations.push(
       linkifyExtra,

--- a/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
@@ -1,7 +1,6 @@
 import MarkdownIt from 'markdown-it'
 import { TocAst } from '../../../external-types/markdown-it-toc-done-right/interface'
 import { RawYAMLMetadata } from '../../editor/yaml-metadata/yaml-metadata'
-import { alertContainer } from '../markdown-it-plugins/alert-container'
 import { documentToc } from '../markdown-it-plugins/document-toc'
 import { frontmatterExtract } from '../markdown-it-plugins/frontmatter'
 import { headlineAnchors } from '../markdown-it-plugins/headline-anchors'
@@ -58,7 +57,6 @@ export class FullMarkdownItConfigurator extends BasicMarkdownItConfigurator {
       highlightedCode,
       quoteExtra,
       (markdownIt) => documentToc(markdownIt, this.onToc),
-      alertContainer,
       (markdownIt) => lineNumberMarker(markdownIt, (lineMarkers) => this.onLineMarkers(lineMarkers))
     )
   }


### PR DESCRIPTION
### Component/Part
markdown renderer

### Description
This PR moves alert container from full renderer to basic renderer.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [x] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog
